### PR TITLE
feat: flatten friends list and refresh apply panel

### DIFF
--- a/src/components/views/FriendsApplyPanel.astro
+++ b/src/components/views/FriendsApplyPanel.astro
@@ -12,19 +12,10 @@ const friendInfo = {
   avatar: 'https://www.wutongyu.site/avatar.webp',
 }
 
-const friendTemplate = `Name: ${friendInfo.name}
+const referenceTemplate = `Name: ${friendInfo.name}
 Desc: ${friendInfo.desc}
 Link: ${friendInfo.link}
 Avatar: ${friendInfo.avatar}`
-
-const referenceTemplate = `{
-  "id": "your-site-id",
-  "name": "你的站点名称",
-  "link": "https://example.com",
-  "avatar": "https://example.com/avatar.png",
-  "desc": "一句话介绍你的站点",
-  "category": "Friends"
-}`
 ---
 
 <aside class="friends-apply" aria-label="申请友链">
@@ -50,37 +41,20 @@ const referenceTemplate = `{
     </Link>
   </section>
 
-  <div class="friends-apply__blocks">
-    <section class="friends-apply__block">
-      <h3>我的友链信息</h3>
-      <div class="friends-apply__code-wrap">
-        <pre id="friend-info">{friendTemplate}</pre>
-        <button
-          class="friends-apply__copy"
-          type="button"
-          data-copy-target="friend-info"
-          aria-label="复制我的友链信息"
-        >
-          复制
-        </button>
-      </div>
-    </section>
-
-    <section class="friends-apply__block">
-      <h3>参考格式</h3>
-      <div class="friends-apply__code-wrap">
-        <pre id="friend-format">{referenceTemplate}</pre>
-        <button
-          class="friends-apply__copy"
-          type="button"
-          data-copy-target="friend-format"
-          aria-label="复制参考格式"
-        >
-          复制
-        </button>
-      </div>
-    </section>
-  </div>
+  <section class="friends-apply__block">
+    <h3>参考格式</h3>
+    <div class="friends-apply__code-wrap">
+      <pre id="friend-format">{referenceTemplate}</pre>
+      <button
+        class="friends-apply__copy"
+        type="button"
+        data-copy-target="friend-format"
+        aria-label="复制参考格式"
+      >
+        复制
+      </button>
+    </div>
+  </section>
 </aside>
 
 <script>
@@ -107,23 +81,28 @@ const referenceTemplate = `{
 <style>
   .friends-apply {
     display: grid;
-    gap: 0;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    align-items: stretch;
     border: 1px solid var(--friends-border);
     border-radius: 1.8rem;
     background: var(--friends-panel-bg);
     overflow: hidden;
   }
 
-  .friends-apply__intro,
+  .friends-apply__intro {
+    padding: 1.25rem 1.15rem 1.35rem 1.3rem;
+  }
+
   .friends-apply__block {
-    padding: 1.25rem 1.3rem 1.35rem;
+    padding: 1.25rem 1.5rem 1.35rem 1.2rem;
   }
 
   .friends-apply__intro {
     display: grid;
-    justify-items: start;
-    gap: 0.7rem;
-    border-bottom: 1px solid var(--friends-border);
+    align-content: start;
+    gap: 0.65rem;
+    min-width: 0;
+    border-right: 1px solid var(--friends-border);
   }
 
   .friends-apply__kicker {
@@ -150,20 +129,21 @@ const referenceTemplate = `{
   }
 
   .friends-apply__rules {
-    display: grid;
-    gap: 0.45rem;
-    margin: 0.15rem 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem 1.5rem;
+    margin: 0.1rem 0 0;
     padding: 0;
     list-style: none;
   }
 
   .friends-apply__rules li {
-    display: grid;
-    grid-template-columns: 1.7rem minmax(0, 1fr);
-    gap: 0.55rem;
+    display: flex;
+    gap: 0.5rem;
     align-items: baseline;
     color: var(--c-text);
     font-size: 0.95rem;
+    white-space: nowrap;
   }
 
   .friends-apply__index {
@@ -174,7 +154,7 @@ const referenceTemplate = `{
   }
 
   .friends-apply__hint {
-    margin: 0.15rem 0 0;
+    margin: 0.1rem 0 0;
     color: var(--friends-muted);
     font-size: 0.9rem;
     line-height: 1.65;
@@ -183,17 +163,25 @@ const referenceTemplate = `{
   .friends-apply__hint code {
     color: var(--c-text);
     font-size: 0.84em;
+    overflow-wrap: anywhere;
   }
 
   .friends-apply__pr {
     margin-top: 0.2rem;
-    color: var(--c-text);
-    text-underline-offset: 0.22rem;
+    justify-self: start;
+    padding: 0.38rem 0.78rem;
+    border: 1px solid var(--friends-border);
+    border-radius: 0.55rem;
+    background: var(--c-bg);
+    color: var(--friends-muted);
+    font-size: 0.86rem;
+    line-height: 1.4;
+    transition: border-color 180ms ease, color 180ms ease;
   }
 
-  .friends-apply__blocks {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .friends-apply__pr:hover {
+    border-color: var(--friends-border-strong);
+    color: var(--c-text);
   }
 
   .friends-apply__block {
@@ -201,10 +189,6 @@ const referenceTemplate = `{
     align-content: start;
     gap: 0.75rem;
     min-width: 0;
-  }
-
-  .friends-apply__block + .friends-apply__block {
-    border-left: 1px solid var(--friends-border);
   }
 
   .friends-apply__code-wrap {
@@ -220,8 +204,8 @@ const referenceTemplate = `{
     color: var(--c-text);
     font-size: 0.84rem;
     line-height: 1.65;
-    overflow-x: auto;
-    white-space: pre;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
   }
 
   .friends-apply__copy {
@@ -242,8 +226,9 @@ const referenceTemplate = `{
     color: var(--c-text);
   }
 
-  @media (max-width: 720px) {
+  @media (max-width: 920px) {
     .friends-apply {
+      grid-template-columns: 1fr;
       border-radius: 1.25rem;
     }
 
@@ -252,13 +237,9 @@ const referenceTemplate = `{
       padding: 1.1rem;
     }
 
-    .friends-apply__blocks {
-      grid-template-columns: 1fr;
-    }
-
-    .friends-apply__block + .friends-apply__block {
-      border-top: 1px solid var(--friends-border);
-      border-left: 0;
+    .friends-apply__intro {
+      border-right: 0;
+      border-bottom: 1px solid var(--friends-border);
     }
 
     .friends-apply pre {

--- a/src/components/views/FriendsApplyPanel.astro
+++ b/src/components/views/FriendsApplyPanel.astro
@@ -1,8 +1,13 @@
 ---
-const email = '15088484799@163.com'
+import Link from '~/components/base/Link.astro'
+
+const dataFilePath = 'src/content/friends/data.json'
+const prUrl =
+  'https://github.com/wutongyuonce/wutong-yu-blog/edit/main/src/content/friends/data.json'
+
 const friendInfo = {
   name: 'Wutong Yu',
-  desc: 'Record of Technology, Open Source, and Personal Thoughts',
+  desc: 'Exploring technology and life',
   link: 'https://www.wutongyu.site/',
   avatar: 'https://www.wutongyu.site/avatar.webp',
 }
@@ -12,15 +17,41 @@ Desc: ${friendInfo.desc}
 Link: ${friendInfo.link}
 Avatar: ${friendInfo.avatar}`
 
-const referenceTemplate = `Name: 你的站点名称
-Desc: 一句话介绍你的站点
-Link: https://example.com
-Avatar: https://example.com/avatar.png`
+const referenceTemplate = `{
+  "id": "your-site-id",
+  "name": "你的站点名称",
+  "link": "https://example.com",
+  "avatar": "https://example.com/avatar.png",
+  "desc": "一句话介绍你的站点",
+  "category": "Friends"
+}`
 ---
 
 <aside class="friends-apply" aria-label="申请友链">
-  <section class="friends-apply__contact">
-    <div class="friends-apply__owner">
+  <section class="friends-apply__intro">
+    <p class="friends-apply__kicker">Apply</p>
+    <h3>交换友链</h3>
+    <ol class="friends-apply__rules">
+      <li>
+        <span class="friends-apply__index">01</span>
+        <span>先友后链</span>
+      </li>
+      <li>
+        <span class="friends-apply__index">02</span>
+        <span>站点使用 https 协议</span>
+      </li>
+    </ol>
+    <p class="friends-apply__hint">
+      在仓库的 <code>{dataFilePath}</code> 数组末尾追加一条对象，补上上一项的逗号，然后提交
+      Pull Request。
+    </p>
+    <Link href={prUrl} external={true} class="friends-apply__pr op-100">
+      在 GitHub 提交 PR
+    </Link>
+  </section>
+
+  <div class="friends-apply__blocks">
+    <section class="friends-apply__block">
       <h3>我的友链信息</h3>
       <div class="friends-apply__code-wrap">
         <pre id="friend-info">{friendTemplate}</pre>
@@ -28,22 +59,28 @@ Avatar: https://example.com/avatar.png`
           class="friends-apply__copy"
           type="button"
           data-copy-target="friend-info"
+          aria-label="复制我的友链信息"
         >
           复制
         </button>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <section class="friends-apply__format">
-    <h3>参考格式</h3>
-    <textarea aria-label="友链参考格式" spellcheck="false"
-      >{referenceTemplate}</textarea
-    >
-    <p class="friends-apply__email">
-      欢迎发送至我的邮箱：<a href={`mailto:${email}`}>{email}</a>
-    </p>
-  </section>
+    <section class="friends-apply__block">
+      <h3>参考格式</h3>
+      <div class="friends-apply__code-wrap">
+        <pre id="friend-format">{referenceTemplate}</pre>
+        <button
+          class="friends-apply__copy"
+          type="button"
+          data-copy-target="friend-format"
+          aria-label="复制参考格式"
+        >
+          复制
+        </button>
+      </div>
+    </section>
+  </div>
 </aside>
 
 <script>
@@ -70,67 +107,121 @@ Avatar: https://example.com/avatar.png`
 <style>
   .friends-apply {
     display: grid;
-    grid-template-columns: minmax(15rem, 0.8fr) minmax(0, 1.2fr);
+    gap: 0;
     border: 1px solid var(--friends-border);
     border-radius: 1.8rem;
     background: var(--friends-panel-bg);
     overflow: hidden;
   }
 
-  .friends-apply__contact,
-  .friends-apply__format {
-    display: grid;
-    align-content: start;
-    gap: 1rem;
-    padding: 1.4rem 1.5rem;
+  .friends-apply__intro,
+  .friends-apply__block {
+    padding: 1.25rem 1.3rem 1.35rem;
   }
 
-  .friends-apply__format {
-    border-left: 1px solid var(--friends-border);
+  .friends-apply__intro {
+    display: grid;
+    justify-items: start;
+    gap: 0.7rem;
+    border-bottom: 1px solid var(--friends-border);
   }
 
-  .friends-apply__owner {
-    display: grid;
-    gap: 1rem;
+  .friends-apply__kicker {
+    margin: 0;
+    color: var(--friends-subtle);
+    font-size: 0.82rem;
+    letter-spacing: 0.02em;
   }
 
   .friends-apply h3 {
     margin: 0;
     color: var(--friends-subtle);
-    font-size: 0.82rem;
-    font-weight: 500;
-    letter-spacing: 0.02em;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .friends-apply__intro h3 {
+    color: var(--c-text);
+    font-size: 1.05rem;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+
+  .friends-apply__rules {
+    display: grid;
+    gap: 0.45rem;
+    margin: 0.15rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .friends-apply__rules li {
+    display: grid;
+    grid-template-columns: 1.7rem minmax(0, 1fr);
+    gap: 0.55rem;
+    align-items: baseline;
+    color: var(--c-text);
+    font-size: 0.95rem;
+  }
+
+  .friends-apply__index {
+    color: var(--friends-subtle);
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .friends-apply__hint {
+    margin: 0.15rem 0 0;
+    color: var(--friends-muted);
+    font-size: 0.9rem;
+    line-height: 1.65;
+  }
+
+  .friends-apply__hint code {
+    color: var(--c-text);
+    font-size: 0.84em;
+  }
+
+  .friends-apply__pr {
+    margin-top: 0.2rem;
+    color: var(--c-text);
+    text-underline-offset: 0.22rem;
+  }
+
+  .friends-apply__blocks {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .friends-apply__block {
+    display: grid;
+    align-content: start;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+
+  .friends-apply__block + .friends-apply__block {
+    border-left: 1px solid var(--friends-border);
   }
 
   .friends-apply__code-wrap {
     position: relative;
   }
 
-  .friends-apply pre,
-  .friends-apply textarea {
-    box-sizing: border-box;
-    width: 100%;
-    min-height: 8.4rem;
-    margin: 0;
-    padding: 0.9rem 1rem;
-    border: 1px solid var(--friends-border);
-    border-radius: 1rem;
-    background: color-mix(in srgb, var(--c-text) 4%, transparent);
-    color: color-mix(in srgb, var(--c-text) 88%, transparent);
-    font:
-      0.9rem/1.65 ui-monospace,
-      SFMono-Regular,
-      Menlo,
-      monospace;
-    overflow-wrap: anywhere;
-  }
-
   .friends-apply pre {
-    white-space: pre-wrap;
-  }
-
-  .friends-apply textarea {
-    resize: vertical;
+    margin: 0;
+    padding: 0.9rem 3.6rem 0.9rem 0.9rem;
+    border: 1px solid var(--friends-border);
+    border-radius: 0.9rem;
+    background: var(--c-bg);
+    color: var(--c-text);
+    font-size: 0.84rem;
+    line-height: 1.65;
+    overflow-x: auto;
+    white-space: pre;
   }
 
   .friends-apply__copy {
@@ -151,37 +242,27 @@ Avatar: https://example.com/avatar.png`
     color: var(--c-text);
   }
 
-  .friends-apply__email {
-    margin: 0;
-    color: var(--friends-muted);
-    font-size: 0.9rem;
-  }
-
-  .friends-apply__email a {
-    color: inherit;
-    overflow-wrap: anywhere;
-    text-underline-offset: 0.2rem;
-  }
-
   @media (max-width: 720px) {
     .friends-apply {
-      grid-template-columns: 1fr;
       border-radius: 1.25rem;
     }
 
-    .friends-apply__contact,
-    .friends-apply__format {
+    .friends-apply__intro,
+    .friends-apply__block {
       padding: 1.1rem;
     }
 
-    .friends-apply__format {
+    .friends-apply__blocks {
+      grid-template-columns: 1fr;
+    }
+
+    .friends-apply__block + .friends-apply__block {
       border-top: 1px solid var(--friends-border);
       border-left: 0;
     }
 
-    .friends-apply pre,
-    .friends-apply textarea {
-      padding: 0.8rem;
+    .friends-apply pre {
+      padding: 0.8rem 3.4rem 0.8rem 0.8rem;
       font-size: 0.82rem;
     }
   }

--- a/src/components/views/FriendsView.astro
+++ b/src/components/views/FriendsView.astro
@@ -1,14 +1,14 @@
 ---
 import Link from '~/components/base/Link.astro'
 import FriendsApplyPanel from '~/components/views/FriendsApplyPanel.astro'
-import { getGroupedFriendsByCategory } from '~/utils/data'
+import { getSortedFriends } from '~/utils/data'
 
 function getInitial(name: string) {
   return name.trim().charAt(0).toUpperCase() || '?'
 }
 
-const groups = await getGroupedFriendsByCategory('friends')
-const isEmpty = groups.length === 0
+const friends = await getSortedFriends('friends')
+const isEmpty = friends.length === 0
 ---
 
 <section class="friends-page">
@@ -29,60 +29,43 @@ const isEmpty = groups.length === 0
     ) : (
       <section class="friends-shell slide-enter">
         <div class="friends-board">
-          <div class="friends-groups">
-            {groups.map((group) => (
-              <section class="friends-group">
-                <header class="friends-group__header">
-                  <div class="friends-group__title-wrap">
-                    <span class="friends-chip">{group.category}</span>
-                    <p class="friends-group__meta">
-                      {group.items.length} 个站点
-                    </p>
-                  </div>
-                </header>
-
-                <div class="friends-grid">
-                  {group.items.map((item) => (
-                    <Link
-                      href={item.data.link}
-                      external={true}
-                      class="friend-card"
-                      title={item.data.desc}
-                    >
-                      <div class="friend-card__avatar-wrap" aria-hidden="true">
-                        {item.data.avatar ? (
-                          <img
-                            class="friend-card__avatar"
-                            src={item.data.avatar}
-                            alt=""
-                            loading="lazy"
-                            decoding="async"
-                            referrerpolicy="no-referrer"
-                          />
-                        ) : (
-                          <span class="friend-card__avatar-fallback">
-                            {getInitial(item.data.name)}
-                          </span>
-                        )}
-                      </div>
-
-                      <div class="friend-card__body">
-                        <div class="friend-card__topline">
-                          <h3>{item.data.name}</h3>
-                        </div>
-
-                        {item.data.siteLabel && (
-                          <p class="friend-card__label">
-                            {item.data.siteLabel}
-                          </p>
-                        )}
-
-                        <p class="friend-card__desc">{item.data.desc}</p>
-                      </div>
-                    </Link>
-                  ))}
+          <div class="friends-grid">
+            {friends.map((item) => (
+              <Link
+                href={item.data.link}
+                external={true}
+                class="friend-card"
+                title={item.data.desc}
+              >
+                <div class="friend-card__avatar-wrap" aria-hidden="true">
+                  {item.data.avatar ? (
+                    <img
+                      class="friend-card__avatar"
+                      src={item.data.avatar}
+                      alt=""
+                      loading="lazy"
+                      decoding="async"
+                      referrerpolicy="no-referrer"
+                    />
+                  ) : (
+                    <span class="friend-card__avatar-fallback">
+                      {getInitial(item.data.name)}
+                    </span>
+                  )}
                 </div>
-              </section>
+
+                <div class="friend-card__body">
+                  <div class="friend-card__topline">
+                    <h3>{item.data.name}</h3>
+                  </div>
+
+                  {item.data.siteLabel && (
+                    <p class="friend-card__label">{item.data.siteLabel}</p>
+                  )}
+
+                  <p class="friend-card__desc">{item.data.desc}</p>
+                </div>
+              </Link>
             ))}
           </div>
         </div>
@@ -143,36 +126,10 @@ const isEmpty = groups.length === 0
     gap: 0.35rem;
   }
 
-  .friends-groups {
-    display: grid;
-    gap: 0;
-  }
-
-  .friends-group {
-    padding: 1.05rem 0.15rem 0.2rem;
-  }
-
-  .friends-group__header {
-    margin-bottom: 1rem;
-  }
-
-  .friends-group__title-wrap {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.8rem;
-  }
-
   .friends-chip {
     color: var(--friends-subtle);
     font-size: 0.82rem;
     letter-spacing: 0.02em;
-  }
-
-  .friends-group__meta {
-    margin: 0;
-    color: var(--friends-muted);
-    font-size: 0.92rem;
   }
 
   .friends-grid {
@@ -366,10 +323,6 @@ const isEmpty = groups.length === 0
       width: 3.3rem;
       height: 3.3rem;
       box-shadow: 0 0 0 0.22rem var(--friends-avatar-ring);
-    }
-
-    .friends-group {
-      padding-inline: 0;
     }
   }
 </style>

--- a/src/content/friends/data.json
+++ b/src/content/friends/data.json
@@ -5,7 +5,7 @@
     "link": "https://antfu.me/",
     "avatar": "https://github.com/antfu.png?size=96",
     "desc": "Vue、Vite 与开源生态的长期建设者。",
-    "category": "大佬们",
+    "category": "Friends",
     "siteLabel": "站在巨人的肩膀上",
     "order": 1
   },
@@ -15,7 +15,7 @@
     "link": "https://www.pseudoyu.com/",
     "avatar": "https://github.com/Pseudoyu.png?size=96",
     "desc": "独立开发、区块链与长期写作的交汇点。",
-    "category": "大佬们",
+    "category": "Friends",
     "siteLabel": "Web3 / 写作 / Indie",
     "order": 2
   },
@@ -25,7 +25,7 @@
     "link": "https://www.ruanyifeng.com/blog/",
     "avatar": "",
     "desc": "长期更新的技术随笔与周刊，是很多人的固定入口。",
-    "category": "大佬们",
+    "category": "Friends",
     "siteLabel": "技术周刊入口",
     "order": 3
   },
@@ -35,7 +35,7 @@
     "link": "https://lucumr.pocoo.org/",
     "avatar": "https://lucumr.pocoo.org/static/avatar-large.jpg",
     "desc": "Founder of Earendil",
-    "category": "大佬们",
+    "category": "Friends",
     "siteLabel": "Earendil, pi",
     "order": 4
   },
@@ -44,8 +44,8 @@
     "name": "Hazenix的后端札记",
     "link": "https://blog.hazenix.top",
     "desc": "全栈偏后端，写技术也写生活。",
-    "category": "独立博客",
-    "order": 1
+    "category": "Friends",
+    "order": 5
   },
   {
     "id": "huizhi's Aside",
@@ -53,8 +53,8 @@
     "link": "https://blog.huizhi.ink",
     "avatar": "https://github.com/huizhiLLL.png",
     "desc": "也许只是些碎碎念吧。",
-    "category": "独立博客",
-    "order": 2
+    "category": "Friends",
+    "order": 6
   },
   {
     "id": "Seeridia's Home",
@@ -62,8 +62,8 @@
     "link": "https://blog.seeridia.top",
     "avatar": "https://www.github.com/Seeridia.png",
     "desc": "Seeridia 的小小小的大窝！",
-    "category": "独立博客",
-    "order": 3
+    "category": "Friends",
+    "order": 7
   },
   {
     "id": "miuo's blog",
@@ -71,8 +71,8 @@
     "link": "https://miuo.me",
     "avatar": "https://miuo.me/avatar.avif",
     "desc": "记录文章、笔记、实验和暂时不想丢掉的内容。",
-    "category": "独立博客",
-    "order": 4
+    "category": "Friends",
+    "order": 8
   },
   {
     "id": "wibus-log",
@@ -80,9 +80,9 @@
     "link": "https://blog.wibus.ren",
     "avatar": "https://avatars.githubusercontent.com/u/62133302?v=4",
     "desc": "Notes on Being Human",
-    "category": "独立博客",
+    "category": "Friends",
     "siteLabel": "Wibus",
-    "order": 5
+    "order": 9
   },
   {
     "id": "joye-personal-blog",
@@ -90,8 +90,8 @@
     "link": "https://joyehuang.me/",
     "avatar": "https://joyehuang.me/favicon/favicon.ico",
     "desc": "Stay hungry, stay foolish",
-    "category": "独立博客",
-    "order": 6
+    "category": "Friends",
+    "order": 10
   },
   {
     "id": "joshua-chen-blog",
@@ -99,8 +99,8 @@
     "link": "https://blog.joshua2008.top/",
     "avatar": "https://blog.joshua2008.top/images/avatar.webp",
     "desc": "AI Agent & Full-Stack Developer",
-    "category": "独立博客",
-    "order": 7
+    "category": "Friends",
+    "order": 11
   },
   {
     "id": "xnnehang",
@@ -108,8 +108,8 @@
     "link": "https://xnnehang.top",
     "avatar": "https://xnnehang.top/avatar.jpg",
     "desc": "写代码是因为爱。",
-    "category": "独立博客",
-    "order": 8
+    "category": "Friends",
+    "order": 12
   },
   {
     "id": "innei",
@@ -117,8 +117,8 @@
     "link": "https://innei.in/",
     "avatar": "https://avatars.githubusercontent.com/u/41265413?v=5",
     "desc": "Innei's personal blog on frontend and full-stack development — TypeScript, React, Next.js, AI engineering, indie hacking, travel and life.",
-    "category": "独立博客",
-    "order": 9
+    "category": "Friends",
+    "order": 13
   },
   {
     "id": "nyakku",
@@ -126,7 +126,7 @@
     "link": "https://nyakku.moe",
     "avatar": "https://nyakku.moe/avatar.jpg",
     "desc": "一个小透明的透明世界",
-    "category": "独立博客",
-    "order": 10
+    "category": "Friends",
+    "order": 14
   }
 ]


### PR DESCRIPTION
## Summary
- Remove the 大佬们 / 独立博客 grouping so all friend sites render in one list, with existing visual order preserved via global order values.
- Change this site's friend-link Desc to Exploring technology and life.
- Restyle the lower apply panel: exchange rules (先友后链, HTTPS), JSON reference format, and a GitHub PR path to src/content/friends/data.json instead of email.

## Review
Herdr pane friends-review reviewed the uncommitted diff: no blocking issues. Applied two non-blocking a11y nits (CTA opacity, copy-button labels).

pnpm check and pnpm build passed. Pre-existing lint errors in unrelated files were not touched.
