### PR TITLE
feat(blogs): 增加响应式标签汇聚与多标签筛选

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 
 ## Blogs 页面
 
+`/blogs/` 会汇总当前 Blog 的全部标签与文章数，支持多标签 AND 筛选。宽屏标签面板位于文章左侧并与 `Blogs` 标题顶部对齐，页面滚动时随正文移出视口；容器宽度不足时自动移动到副标题与年份列表之间。完整设计和实现见 [`docs/feature/Blogs标签汇聚与筛选说明.md`](docs/feature/Blogs标签汇聚与筛选说明.md)。
+
 <p align="center">
   <img src="img/PixPin_2026-08-16_00-20-34.png" alt="图片" width="600">
 </p>
@@ -66,6 +68,7 @@
 
 - 首页 `/`
 - 博客索引 `/blogs/` 与文章页 `/blogs/[slug]/`
+- 博客索引支持标签计数、响应式多标签 AND 筛选及明暗主题
 - 项目展示页 `/projects/`，支持紧凑分类网格和可选图标
 - Insights 页 `/insights/`，当前为预留空白页，保留独立路由，方便后续重新开发
 - Friends 页 `/friends/`，按分类展示友链卡片，包含邮箱与申请格式面板，并适配明暗主题
@@ -106,6 +109,7 @@ pnpm dev          # 启动本地开发服务器
 pnpm check        # 运行 Astro 类型与内容检查
 pnpm build        # 生成生产环境构建产物
 pnpm preview      # 本地预览生产构建
+pnpm test:blog-tags # 验证博客标签汇总与 AND 匹配逻辑
 pnpm lint         # 运行 ESLint 检查
 pnpm lint:fix     # 自动修复 lint 问题
 pnpm format       # 检查代码格式（Prettier）
@@ -117,7 +121,7 @@ pnpm format:write # 格式化代码（Prettier）
 | 路由 | 用途 |
 | :--- | :--- |
 | `/` | 首页：自定义标题区、复古桌面与个人内容 |
-| `/blogs/` | 博客索引页 |
+| `/blogs/` | 博客索引页：标签汇聚、计数与多标签 AND 筛选 |
 | `/blogs/[slug]/` | 博客文章详情页 |
 | `/projects/` | 项展示页：紧凑分类网格，图标可选 |
 | `/insights/` | Insights 页：当前为预留空白页，仅保留独立路由与基础页面壳 |
@@ -153,7 +157,7 @@ src/
     home/         # HomeHeader, TinyDesktop
     nav/          # NavBar, NavItem, NavSwitch
     toc/          # Toc, TocSidebar, TocItem
-    views/        # RenderPage, RenderPost, ListView, GroupView, InsightsView, FriendsView
+    views/        # 页面组合；ListView 与 TagFilter 负责博客列表及标签筛选
     widgets/      # LogoButton, SearchSwitch, ThemeSwitch, BackLink
   content/
     blogs/        # 博客文章（Markdown / MDX）
@@ -165,7 +169,8 @@ src/
   layouts/        # BaseLayout, StandardLayout
   pages/          # 路由定义
   styles/         # main.css, prose.css, markdown.css
-  utils/          # 路径、日期、数据、杂项、目录工具函数
+  utils/          # 路径、日期、数据、标签筛选、杂项、目录工具函数
+test/             # Node 内置测试，目前覆盖博客标签纯逻辑
 plugins/          # remark/rehype 插件、OG 辅助
 public/           # 静态资源：favicon、字体、生成的图片等
 docs/             # 项目笔记与定制说明文档
@@ -195,6 +200,7 @@ src/components/* + styles/*  -> 最终 UI 输出
 项目相关说明文档存放在 `docs/` 目录下：
 
 - `docs/项目解析.md` — 完整的项目架构与数据流分析
+- `docs/feature/Blogs标签汇聚与筛选说明.md` — Blogs 标签数据、AND 筛选、响应式布局与维护方式
 - `docs/feature/Insights模块更新说明.md` — Insights 模块当前状态、链路与后续恢复说明
 - `docs/feature/友链模块说明.md` — Friends 模块结构、数据链路与维护说明
 - `docs/feature/文章TOC与响应式导航说明.md` — 目录行为与响应式导航细节

--- a/README_ENG.md
+++ b/README_ENG.md
@@ -26,6 +26,8 @@ The homepage uses a dedicated `HomeHeader` with a pure-CSS retro desktop illustr
 </p>
 ## Blogs Page
 
+`/blogs/` aggregates every visible post tag with its post count and supports multi-tag AND filtering. On wide screens the tag panel sits to the left and aligns with the `Blogs` heading; it scrolls away with the document. When the container becomes narrow, it moves between the subtitle and year groups. See [`docs/feature/Blogs标签汇聚与筛选说明.md`](docs/feature/Blogs标签汇聚与筛选说明.md) for the source-level design and implementation notes.
+
 <p align="center">
   <img src="img/PixPin_2026-08-16_00-20-34.png" alt="图片" width="600">
 </p>
@@ -69,6 +71,7 @@ The request area uses a two-column email and submission-format panel that collap
 
 - Home page at `/`
 - Blog index at `/blogs/` and article pages at `/blogs/[slug]/`
+- Responsive blog tag counts and multi-tag AND filtering with light/dark themes
 - Project showcase page at `/projects/` with compact category grids and optional icons
 - Insights page at `/insights/`, currently kept as a blank placeholder route for future redevelopment
 - Friends page at `/friends/` with category-grouped cards, an email/submission-format panel, and light/dark theme support
@@ -109,6 +112,7 @@ pnpm dev          # start local development server
 pnpm check        # run Astro type/content checks
 pnpm build        # create production build
 pnpm preview      # preview the production build locally
+pnpm test:blog-tags # verify blog tag aggregation and AND matching
 pnpm lint         # run ESLint
 pnpm lint:fix     # fix lint issues where possible
 pnpm format       # check formatting with Prettier
@@ -120,7 +124,7 @@ pnpm format:write # format files with Prettier
 | Route | Purpose |
 | :--- | :--- |
 | `/` | Homepage with a custom header, retro desktop, and profile content |
-| `/blogs/` | Blog index |
+| `/blogs/` | Blog index with tag aggregation, counts, and multi-tag AND filtering |
 | `/blogs/[slug]/` | Blog post detail page |
 | `/projects/` | Compact categorized project grid with optional icons |
 | `/insights/` | Insights page: currently a blank placeholder route with only the base page shell |
@@ -156,7 +160,7 @@ src/
     home/         # HomeHeader, TinyDesktop
     nav/          # NavBar, NavItem, NavSwitch
     toc/          # Toc, TocSidebar, TocItem
-    views/        # RenderPage, RenderPost, ListView, GroupView, InsightsView, FriendsView
+    views/        # page composition; ListView and TagFilter power the blog index filtering
     widgets/      # LogoButton, SearchSwitch, ThemeSwitch, BackLink
   content/
     blogs/        # Blog posts (Markdown / MDX)
@@ -168,7 +172,8 @@ src/
   layouts/        # BaseLayout, StandardLayout
   pages/          # Route definitions
   styles/         # main.css, prose.css, markdown.css
-  utils/          # path, datetime, data, misc, toc helpers
+  utils/          # path, datetime, data, blog tag filtering, misc, and TOC helpers
+test/             # Node built-in tests, currently covering blog tag logic
 plugins/          # remark/rehype plugins, OG helpers
 public/           # Static assets such as favicon, fonts, and generated images
 docs/             # Project notes and customization documents
@@ -198,6 +203,7 @@ src/components/* + styles/*  -> final UI output
 Project-specific notes are kept in `docs/`:
 
 - `docs/项目解析.md` - Full project architecture and data flow analysis
+- `docs/feature/Blogs标签汇聚与筛选说明.md` - Blog tag data, AND filtering, responsive layout, and maintenance notes
 - `docs/feature/Insights模块更新说明.md` - Current Insights module status, wiring, and restoration notes
 - `docs/feature/友链模块说明.md` - Friends module structure, data flow, and maintenance guide
 - `docs/feature/文章TOC与响应式导航说明.md` - TOC behavior and responsive navigation details

--- a/docs/feature/Blogs标签汇聚与筛选说明.md
+++ b/docs/feature/Blogs标签汇聚与筛选说明.md
@@ -1,0 +1,190 @@
+# Blogs 标签汇聚与筛选说明
+
+本文档以当前代码为准，说明 `/blogs/` 标签汇聚、多标签筛选、响应式布局和后续维护方式。最初设计、实现讨论与验收记录见 [Issue #19](https://github.com/wutongyuonce/wutong-yu-blog/issues/19)。
+
+## 1. 用户可见行为
+
+- 页面汇总当前列表中所有 Blog 的标签，并显示每个标签对应的文章数。
+- 点击标签立即改变选中样式，约 `140ms` 后刷新文章列表。
+- 可同时选择多个标签；文章必须包含全部已选标签才会显示，即 AND 语义。
+- 取消标签或点击 `Clear` 后重新计算结果；无选择时显示全部文章。
+- 没有匹配文章时隐藏所有年份标题，显示空状态和清空入口。
+- 年份分组仍按原顺序保留，只隐藏没有可见文章的年份。
+- 筛选状态不写入 URL 或 localStorage，离开页面后不会持久化。
+
+## 2. 数据来源与计算规则
+
+标签面板不维护独立配置，数据来自与文章列表相同的 `getGroupedPostsByYear('blogs')` 结果：
+
+```text
+src/content/blogs/**/*.md(x) frontmatter.tags
+        ↓
+getFilteredPosts('blogs')
+        ↓
+getSortedPosts() + getGroupedPostsByYear()
+        ↓
+normalizePostTags() + buildTagSummary()
+        ↓
+TagFilter.astro + ListItem.astro
+```
+
+生产构建会先排除 draft，因此生产环境的标签计数只统计实际展示的文章。开发环境会与当前开发列表保持一致。
+
+计算规则：
+
+1. 每篇文章的标签先执行 `trim()`。
+2. 空字符串被忽略。
+3. 同一篇文章内的重复标签只计数一次。
+4. 标签身份保持大小写敏感。
+5. 标签按文章数降序排列；计数相同时使用中文 locale 稳定排序。
+6. 可见标签名最多保留 12 个 Unicode code point，完整值仍用于筛选、`title` 和无障碍名称。
+
+## 3. 客户端筛选机制
+
+`ListView.astro` 在构建阶段输出全部文章，并把每篇文章的规范化标签序列化到 `data-tags`。浏览器端不重新请求数据，也不重新创建列表节点。
+
+客户端初始化后缓存：
+
+- 标签按钮
+- 文章节点与标签数组
+- 年份分组节点
+- 当前 `Set<string>` 选择集合
+- 防抖 timer、操作 revision 和当前 Web Animation
+
+筛选条件为：
+
+```text
+selectedTags 为空 -> 全部文章匹配
+selectedTags 非空 -> selectedTags 中每个标签都存在于 postTags
+```
+
+一次选择变化的流程：
+
+```text
+点击标签
+  → 立即更新 aria-pressed、颜色和已选数量
+  → 取消旧 timer / animation
+  → 140ms trailing debounce
+  → 列表淡出 90ms
+  → 批量切换文章和年份的 hidden
+  → 列表淡入 140ms
+  → 更新 aria-live 结果数
+```
+
+revision 用于拒绝旧选择快照，避免快速连续点击后旧结果覆盖新结果。`prefers-reduced-motion: reduce` 下跳过淡入淡出，只执行防抖后的原子更新。
+
+项目启用了 Astro `ClientRouter`。初始化同时在脚本执行时和 `astro:page-load` 后运行，并通过 `data-initialized` 防止重复绑定。
+
+## 4. 响应式布局
+
+### 4.1 宽屏
+
+`ListView.astro` 使用对称三列网格：
+
+```css
+grid-template-columns:
+  minmax(14rem, 18rem)
+  65ch
+  minmax(14rem, 18rem);
+```
+
+- 标签面板位于左列。
+- 文章位于固定 `65ch` 的中列。
+- 右列作为对称留白，保证文章列与页面标题保持同一中心线和左边缘。
+- 标签面板用 `margin-top: -9.3125rem` 与 `Blogs` 标题顶部对齐。
+- 标签面板使用普通文档流，不使用 sticky/fixed；页面向下滚动时会随内容移出视口。
+
+### 4.2 窄屏
+
+外层使用 container query，在 Blog 容器宽度不超过 `76rem` 时切换为单列：
+
+```text
+Blogs
+Record my Trajectory
+标签面板
+年份标题
+文章列表
+```
+
+窄屏会把标签面板的负上边距恢复为 `0`。布局不依赖 JavaScript 监听窗口宽度，也不会绝对定位，因此不会与年份标题重叠。
+
+标签按钮区域使用 `flex-wrap` 自动换行。当前紧凑参数为：
+
+- 最小宽度：`3.75rem`
+- 最小高度：`2.05rem`
+- 圆角：`0.35rem`
+- 标签间距：`0.35rem`
+- 标签文字：`0.8125rem`
+- 右下角计数：`0.5625rem`
+
+## 5. 主题与可访问性
+
+- Light 与 Dark 分别定义默认背景、边框、hover、选中背景和反相文字 token。
+- 标签使用原生 `<button type="button">`，键盘可通过 Tab、Space 和 Enter 操作。
+- `aria-pressed` 是选中状态的语义来源。
+- 完整标签与文章数进入按钮的无障碍名称。
+- 筛选结果通过 `aria-live="polite"` 汇报。
+- 全站 `:focus-visible` 样式继续负责键盘焦点提示。
+
+## 6. 文件职责
+
+| 文件 | 职责 |
+| :-- | :-- |
+| `src/pages/blogs/index.mdx` | Blogs 路由入口；不再用 `.prose` 限制整个默认 slot |
+| `src/components/views/ListView.astro` | 获取年份分组、生成标签摘要、输出响应式布局并管理客户端筛选 |
+| `src/components/views/TagFilter.astro` | 输出标签按钮、计数、Clear 和明暗主题样式 |
+| `src/components/views/ListItem.astro` | 输出单篇文章标题、日期、阅读时长和标签文本 |
+| `src/utils/blog-tag-filter.js` | 标签规范化、汇总、AND 匹配与 Unicode 截断纯函数 |
+| `test/blog-tag-filter.test.mjs` | 使用 Node 内置测试验证标签纯逻辑 |
+| `src/content/blogs/**/*.md(x)` | 唯一标签内容源，由每篇文章 frontmatter 维护 |
+
+## 7. 本次标签收敛
+
+本功能实现期间按内容主题收敛了以下文章的标签：
+
+| Blog | 当前标签 |
+| :-- | :-- |
+| 本机 Homebrew 工具笔记 | `macOS` |
+| 前后端鉴权方案 | `鉴权` |
+| Astro Notes | `Astro` |
+| 创建 Agent Skill 的最佳实践 | `Skill` |
+| MCP（Model Context Protocol） | `MCP` |
+| Prompt Caching 的工程策略 | `Prompt Caching`、`KV Cache` |
+| Agent 开发习惯 | `Agent` |
+| 从零写 CLI | `CLI` |
+| Claude Code 记忆系统笔记 | `Claude Code`、`Agent Memory` |
+| 云端 Agent | `Cloud Agent`、`VM/FS` |
+| DeepSeek Harness 架构解析 | `DSH`、`Agent Harness` |
+| RAG 系统测试 | `RAG`、`Eval` |
+| 看懂 memU | `memU`、`Agent Memory` |
+| Agent 上线前常用的系统测试方法总述 | `Agent`、`Eval` |
+| KV、Prefix、Prompt 与 Context Caching | `KV Cache` |
+| OpenViking PR #4736 | `OpenViking`、`Agent`、`Memory`、`PR` |
+| memU PR #675 | `memU`、`Agent Memory`、`Pi` |
+| Deer Workflow PR #7 | `Workflow`、`Pi`、`Multi-Agent` |
+
+后续修改标签时只编辑文章 frontmatter；面板计数和筛选会在下一次构建时自动更新。
+
+## 8. 验证
+
+```bash
+pnpm test:blog-tags
+pnpm build
+```
+
+浏览器至少验证：
+
+- 1280px 宽屏标题对齐
+- 1024px 与 390px 单列顺序及无横向溢出
+- Light / Dark
+- 单选、多选 AND、快速连续选择、零结果和 Clear
+- Astro 客户端导航离开并返回 Blogs
+
+当前仓库的全量 `pnpm check` 和 `pnpm lint` 存在与本功能无关的既有基线错误。修复基线前，不能把这两个命令描述为全量通过。
+
+## 9. 后续修改入口
+
+- 先阅读本文档了解当前代码事实。
+- 查看 [Issue #19](https://github.com/wutongyuonce/wutong-yu-blog/issues/19) 了解设计取舍、实现偏差和验收背景。
+- 修改筛选语义时同步更新纯函数与 `test/blog-tag-filter.test.mjs`。
+- 修改响应式断点、标签尺寸或标题对齐时同步检查 1280px、1024px 和 390px。

--- a/docs/项目解析.md
+++ b/docs/项目解析.md
@@ -1245,8 +1245,8 @@ getSortedPosts()
 getGroupedPostsByYear()
         ↓
 ListView.astro
-        ↓
-ListItem.astro
+        ├── normalizePostTags() + buildTagSummary() → TagFilter.astro
+        └── ListItem.astro
 ```
 
 `Insights` 相关工具函数当前保留，但页面侧链路已经断开，现状更接近：
@@ -1803,7 +1803,8 @@ TocSidebar.astro / TocItem.astro
 | :----------------- | :-------------- |
 | `RenderPage.astro` | 渲染普通内容条目        |
 | `RenderPost.astro` | 渲染博客详情          |
-| `ListView.astro`   | 渲染博客列表          |
+| `ListView.astro`   | 渲染博客列表、标签汇总与筛选   |
+| `TagFilter.astro`  | 渲染可多选的标签计数面板     |
 | `ListItem.astro`   | 渲染单个博客列表项       |
 | `GroupView.astro`  | 渲染项目页分组         |
 | `GroupItem.astro`  | 渲染项目卡片网格        |
@@ -1848,8 +1849,17 @@ PostMeta + Toc(DesktopAside + MobileTocControl) + PostCover + Content
 负责：
 
 - 从 `getGroupedPostsByYear(collectionType)` 拉取并分组博客
+- 从同一份可见文章数据汇总标签及文章数，避免额外读取内容集合
+- 在宽屏使用对称三列布局，将标签面板与 `Blogs` 标题顶部对齐；容器小于 `76rem` 时将其放回副标题与年份列表之间
+- 标签面板保持普通文档流定位，不使用 `sticky` 或 `fixed`，向下滚动后会自然移出视口
+- 为每篇文章输出标准化后的 `data-tags`，供浏览器端筛选
+- 使用多标签 AND 语义筛选文章，并同步隐藏无匹配文章的年份和显示空状态
+- 对连续点击使用 `140ms` 防抖和修订号保护，并用淡出、更新、淡入控制视觉刷新
+- 在 Astro ClientRouter 导航后幂等初始化，避免重复绑定事件
 - 根据年份输出 `Categorizer`
 - 渲染多个 `ListItem`
+
+标签汇总、匹配和截断等纯逻辑位于 `src/utils/blog-tag-filter.js`，并由 `test/blog-tag-filter.test.mjs` 直接验证。当前行为与维护边界详见 `docs/feature/Blogs标签汇聚与筛选说明.md`。
 
 #### `collectionType` 与 `urlPath` 的区别
 
@@ -1859,6 +1869,15 @@ PostMeta + Toc(DesktopAside + MobileTocControl) + PostCover + Content
 - `urlPath="blogs"`：表示列表项链接使用 `/blogs/` 作为 URL 前缀
 
 在当前项目里，这两个值刚好保持一致；同时组件仍保留 `urlPath` 这个入口，方便以后把“数据来源”和“页面前缀”拆开控制。
+
+### 16.4.1 `TagFilter.astro`
+
+负责：
+
+- 按计数降序、标签名升序渲染全部标签
+- 以 `aria-pressed` 表达多选状态，并提供清空入口与结果播报区域
+- 对标签名进行 Unicode 安全的显示截断，同时保留完整名称作为筛选值和提示文本
+- 提供紧凑标签块、明暗主题、键盘焦点和 `prefers-reduced-motion` 样式
 
 ### 16.5 `ListItem.astro`
 
@@ -1985,6 +2004,7 @@ RenderPage(collectionType='home', id='index')
 - 设置页面级 frontmatter
 - 当前副标题为 `Record my Trajectory`
 - 使用 `ListView collectionType="blogs" urlPath="blogs"`
+- 不为整个默认插槽套用 `.prose` 宽度；文章主列仍由 `ListView` 固定为 `65ch`，外围空间用于宽屏标签面板
 - 把页面最终渲染为 `/blogs/`
 
 ### 17.3 `src/pages/blogs/[...slug].astro`
@@ -2094,12 +2114,15 @@ src/content/home/index.md
 src/pages/blogs/index.mdx
     ↓
 ListView.astro
-    ↓
-getGroupedPostsByYear('blogs')
-    ↓
-getFilteredPosts('blogs') + getSortedPosts()
-    ↓
-ListItem.astro
+    ├── getGroupedPostsByYear('blogs')
+    │       ↓
+    │   getFilteredPosts('blogs') + getSortedPosts()
+    ├── normalizePostTags() + buildTagSummary()
+    │       ↓
+    │   TagFilter.astro
+    │       ↓ 140ms 防抖、多标签 AND 匹配
+    │   更新文章、年份与空状态的可见性
+    └── ListItem.astro
     ↓
 /blogs/[...slug]/
 ```

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check": "astro check",
     "build": "astro build",
     "preview": "astro preview",
+    "test:blog-tags": "node --test test/blog-tag-filter.test.mjs",
     "format": "prettier . --check --ignore-unknown",
     "format:write": "prettier . --write --ignore-unknown --cache",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0 --cache",

--- a/src/components/views/ListView.astro
+++ b/src/components/views/ListView.astro
@@ -1,8 +1,14 @@
 ---
 import Categorizer from '~/components/base/Categorizer.astro'
 import ListItem from '~/components/views/ListItem.astro'
+import TagFilter from '~/components/views/TagFilter.astro'
 
 import { getGroupedPostsByYear } from '~/utils/data'
+import {
+  buildTagSummary,
+  normalizePostTags,
+  truncateTagLabel,
+} from '~/utils/blog-tag-filter.js'
 
 interface Props {
   collectionType: 'blogs'
@@ -12,44 +18,331 @@ interface Props {
 const { collectionType, urlPath = collectionType } = Astro.props
 
 const groupedBlogItems = await getGroupedPostsByYear(collectionType)
+const allBlogItems = groupedBlogItems.flatMap((group) => group.items)
+const tagSummary = buildTagSummary(
+  allBlogItems.map(({ data }) => data.tags)
+).map(({ tag, count }) => ({
+  tag,
+  count,
+  displayName: truncateTagLabel(tag),
+}))
 ---
 
-{
-  <div aria-label="Post list">
-    {groupedBlogItems.length === 0 ? (
-      <div class="py-2 op-50">nothing here yet</div>
-    ) : (
-      groupedBlogItems.map((group) => {
-        const idx = group.items[0].idx
+<div
+  class="blog-browser"
+  data-blog-browser
+  data-total-posts={allBlogItems.length}
+>
+  <div
+    class="blog-browser__layout"
+    data-has-tags={tagSummary.length > 0 ? '' : undefined}
+  >
+    {tagSummary.length > 0 && <TagFilter tags={tagSummary} />}
 
-        return (
-          <section data-year={group.year} class="blog-year-group mb-16">
-            <Categorizer {idx} text={group.year} />
+    <div class="blog-browser__posts prose">
+      <p class="sr-only" aria-live="polite" data-filter-status>
+        Showing all {allBlogItems.length} posts.
+      </p>
 
-            {group.items.map(({ data, id, minutesRead, idx }) => (
-              <ListItem
-                {idx}
-                urlPath={urlPath}
-                postSlug={id}
-                title={data.title}
-                tags={data.tags}
-                date={data.pubDate}
-                minutesRead={minutesRead}
-                radio={data.radio}
-                video={data.video}
-                platform={data.platform}
-                redirect={data.redirect}
-              />
-            ))}
-          </section>
-        )
-      })
-    )}
+      <div aria-label="Post list" data-post-list>
+        {
+          groupedBlogItems.length === 0 ? (
+            <div class="py-2 op-50">nothing here yet</div>
+          ) : (
+            groupedBlogItems.map((group) => {
+              const idx = group.items[0].idx
+
+              return (
+                <section
+                  data-year={group.year}
+                  data-year-group
+                  class="blog-year-group mb-16"
+                >
+                  <Categorizer {idx} text={group.year} />
+
+                  {group.items.map(({ data, id, minutesRead, idx }) => (
+                    <div
+                      data-blog-item
+                      data-tags={JSON.stringify(normalizePostTags(data.tags))}
+                    >
+                      <ListItem
+                        {idx}
+                        urlPath={urlPath}
+                        postSlug={id}
+                        title={data.title}
+                        tags={data.tags}
+                        date={data.pubDate}
+                        minutesRead={minutesRead}
+                        radio={data.radio}
+                        video={data.video}
+                        platform={data.platform}
+                        redirect={data.redirect}
+                      />
+                    </div>
+                  ))}
+                </section>
+              )
+            })
+          )
+        }
+      </div>
+
+      <div class="blog-browser__empty" data-filter-empty hidden>
+        <p>No posts match all selected tags.</p>
+        <button type="button" data-clear-tags>Clear filters</button>
+      </div>
+    </div>
   </div>
-}
+</div>
 
 <style>
+  .blog-browser {
+    width: 100%;
+    max-width: 100rem;
+    margin-inline: auto;
+    container: blog-browser / inline-size;
+  }
+
+  .blog-browser__layout {
+    display: grid;
+    grid-template-columns:
+      minmax(14rem, 18rem)
+      65ch
+      minmax(14rem, 18rem);
+    justify-content: center;
+    gap: clamp(1.5rem, 3vw, 3.5rem);
+    font-size: var(--blog-reading-size);
+  }
+
+  .blog-browser__layout > :global(.tag-filter) {
+    position: sticky;
+    top: 6rem;
+    align-self: start;
+    max-height: calc(100dvh - 8rem);
+    overflow-y: auto;
+  }
+
+  .blog-browser__posts {
+    grid-column: 2;
+    width: 100%;
+    min-width: 0;
+  }
+
   .blog-year-group:last-child {
     margin-bottom: 0;
   }
+
+  .blog-browser__empty {
+    padding-block: 1rem 2rem;
+    text-align: center;
+    opacity: 0.62;
+  }
+
+  .blog-browser__empty p {
+    margin: 0 0 0.75rem;
+  }
+
+  .blog-browser__empty button {
+    padding: 0;
+    border: 0;
+    color: inherit;
+    background: transparent;
+    font: inherit;
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+    cursor: pointer;
+  }
+
+  @container blog-browser (max-width: 76rem) {
+    .blog-browser__layout {
+      grid-template-columns: minmax(0, 65ch);
+      justify-content: center;
+      gap: 2.5rem;
+    }
+
+    .blog-browser__layout > :global(.tag-filter) {
+      position: static;
+      grid-row: 1;
+      max-height: none;
+      overflow: visible;
+    }
+
+    .blog-browser__posts {
+      grid-row: 2;
+      grid-column: 1;
+    }
+
+    .blog-browser__layout:not([data-has-tags]) .blog-browser__posts {
+      grid-row: 1;
+    }
+  }
+
+  @container blog-browser (max-width: 40rem) {
+    .blog-browser__layout {
+      gap: 2rem;
+    }
+  }
 </style>
+
+<script>
+  import { matchesAllTags } from '~/utils/blog-tag-filter.js'
+
+  const FILTER_DELAY_MS = 140
+  const FADE_OUT_MS = 90
+  const FADE_IN_MS = 140
+
+  const initializeBlogTagFilters = () => {
+    const roots = document.querySelectorAll<HTMLElement>(
+      '[data-blog-browser]:not([data-initialized])'
+    )
+
+    roots.forEach((root) => {
+      root.dataset.initialized = 'true'
+
+      const postList = root.querySelector<HTMLElement>('[data-post-list]')
+      const status = root.querySelector<HTMLElement>('[data-filter-status]')
+      const emptyState = root.querySelector<HTMLElement>('[data-filter-empty]')
+      const selectedCount = root.querySelector<HTMLElement>(
+        '[data-selected-count]'
+      )
+      const tagButtons = [
+        ...root.querySelectorAll<HTMLButtonElement>('[data-tag]'),
+      ]
+      const clearButtons = [
+        ...root.querySelectorAll<HTMLButtonElement>('[data-clear-tags]'),
+      ]
+
+      if (!postList || !status || !emptyState || !selectedCount) return
+
+      const posts = [
+        ...root.querySelectorAll<HTMLElement>('[data-blog-item]'),
+      ].map((element) => ({
+        element,
+        tags: JSON.parse(element.dataset.tags ?? '[]') as string[],
+      }))
+      const yearGroups = [
+        ...root.querySelectorAll<HTMLElement>('[data-year-group]'),
+      ]
+      const selectedTags = new Set<string>()
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
+      let timer: number | undefined
+      let revision = 0
+      let animation: Animation | undefined
+
+      const updateControls = () => {
+        tagButtons.forEach((button) => {
+          button.setAttribute(
+            'aria-pressed',
+            selectedTags.has(button.dataset.tag ?? '') ? 'true' : 'false'
+          )
+        })
+
+        selectedCount.textContent = `${selectedTags.size} selected`
+        clearButtons.forEach((button) => {
+          button.hidden = selectedTags.size === 0
+        })
+      }
+
+      const updateVisibility = (selection: Set<string>) => {
+        let visiblePosts = 0
+
+        posts.forEach(({ element, tags }) => {
+          const visible = matchesAllTags(tags, selection)
+          element.hidden = !visible
+          if (visible) visiblePosts += 1
+        })
+
+        yearGroups.forEach((group) => {
+          group.hidden = !group.querySelector('[data-blog-item]:not([hidden])')
+        })
+
+        emptyState.hidden = visiblePosts !== 0
+        status.textContent =
+          selection.size === 0
+            ? `Showing all ${posts.length} posts.`
+            : `Showing ${visiblePosts} of ${posts.length} posts.`
+      }
+
+      const applyFilter = async (expectedRevision: number) => {
+        const selection = new Set(selectedTags)
+
+        if (reduceMotion.matches || typeof postList.animate !== 'function') {
+          if (expectedRevision === revision) updateVisibility(selection)
+          return
+        }
+
+        const fadeOut = postList.animate(
+          [
+            { opacity: 1, transform: 'translateY(0)' },
+            { opacity: 0.25, transform: 'translateY(2px)' },
+          ],
+          { duration: FADE_OUT_MS, easing: 'ease-out', fill: 'forwards' }
+        )
+        animation = fadeOut
+
+        try {
+          await fadeOut.finished
+        } catch {
+          return
+        }
+
+        if (expectedRevision !== revision) return
+        fadeOut.cancel()
+        updateVisibility(selection)
+
+        const fadeIn = postList.animate(
+          [
+            { opacity: 0.25, transform: 'translateY(2px)' },
+            { opacity: 1, transform: 'translateY(0)' },
+          ],
+          { duration: FADE_IN_MS, easing: 'ease-out' }
+        )
+        animation = fadeIn
+
+        try {
+          await fadeIn.finished
+        } catch {
+          return
+        }
+
+        if (animation === fadeIn) animation = undefined
+      }
+
+      const queueFilter = () => {
+        revision += 1
+        const expectedRevision = revision
+        window.clearTimeout(timer)
+        animation?.cancel()
+        timer = window.setTimeout(
+          () => void applyFilter(expectedRevision),
+          FILTER_DELAY_MS
+        )
+      }
+
+      tagButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const tag = button.dataset.tag
+          if (!tag) return
+
+          if (selectedTags.has(tag)) selectedTags.delete(tag)
+          else selectedTags.add(tag)
+
+          updateControls()
+          queueFilter()
+        })
+      })
+
+      clearButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          if (selectedTags.size === 0) return
+          selectedTags.clear()
+          updateControls()
+          queueFilter()
+        })
+      })
+    })
+  }
+
+  initializeBlogTagFilters()
+  document.addEventListener('astro:page-load', initializeBlogTagFilters)
+</script>

--- a/src/components/views/ListView.astro
+++ b/src/components/views/ListView.astro
@@ -115,12 +115,8 @@ const tagSummary = buildTagSummary(
   }
 
   .blog-browser__layout > :global(.tag-filter) {
-    position: sticky;
-    top: 7.75rem;
     align-self: start;
     margin-top: -9.3125rem;
-    max-height: calc(100dvh - 8rem);
-    overflow-y: auto;
   }
 
   .blog-browser__posts {
@@ -162,11 +158,8 @@ const tagSummary = buildTagSummary(
     }
 
     .blog-browser__layout > :global(.tag-filter) {
-      position: static;
       grid-row: 1;
       margin-top: 0;
-      max-height: none;
-      overflow: visible;
     }
 
     .blog-browser__posts {

--- a/src/components/views/ListView.astro
+++ b/src/components/views/ListView.astro
@@ -118,6 +118,7 @@ const tagSummary = buildTagSummary(
     position: sticky;
     top: 6rem;
     align-self: start;
+    margin-top: -9.3125rem;
     max-height: calc(100dvh - 8rem);
     overflow-y: auto;
   }
@@ -163,6 +164,7 @@ const tagSummary = buildTagSummary(
     .blog-browser__layout > :global(.tag-filter) {
       position: static;
       grid-row: 1;
+      margin-top: 0;
       max-height: none;
       overflow: visible;
     }

--- a/src/components/views/ListView.astro
+++ b/src/components/views/ListView.astro
@@ -116,7 +116,7 @@ const tagSummary = buildTagSummary(
 
   .blog-browser__layout > :global(.tag-filter) {
     position: sticky;
-    top: 6rem;
+    top: 7.75rem;
     align-self: start;
     margin-top: -9.3125rem;
     max-height: calc(100dvh - 8rem);

--- a/src/components/views/TagFilter.astro
+++ b/src/components/views/TagFilter.astro
@@ -1,0 +1,192 @@
+---
+interface TagSummary {
+  tag: string
+  count: number
+  displayName: string
+}
+
+interface Props {
+  tags: TagSummary[]
+}
+
+const { tags } = Astro.props
+---
+
+<aside class="tag-filter" aria-labelledby="blog-tag-filter-title">
+  <div class="tag-filter__heading">
+    <h2 id="blog-tag-filter-title">Tags</h2>
+    <div class="tag-filter__actions">
+      <span class="tag-filter__selected" data-selected-count> 0 selected </span>
+      <button type="button" class="tag-filter__clear" data-clear-tags hidden>
+        Clear
+      </button>
+    </div>
+  </div>
+
+  <div
+    class="tag-filter__items"
+    role="group"
+    aria-labelledby="blog-tag-filter-title"
+  >
+    {
+      tags.map(({ tag, count, displayName }) => (
+        <button
+          type="button"
+          class="tag-filter__chip"
+          data-tag={tag}
+          aria-label={`${tag}, ${count} ${count === 1 ? 'post' : 'posts'}`}
+          aria-pressed="false"
+          title={tag}
+        >
+          <span class="tag-filter__label">{displayName}</span>
+          <span class="tag-filter__count" aria-hidden="true">
+            {count}
+          </span>
+        </button>
+      ))
+    }
+  </div>
+</aside>
+
+<style>
+  .tag-filter {
+    --tag-text: #4b5563;
+    --tag-bg: #00000008;
+    --tag-border: #00000018;
+    --tag-hover: #00000010;
+    --tag-selected-bg: #1f2937;
+    --tag-selected-text: #fff;
+
+    min-width: 0;
+    color: var(--tag-text);
+  }
+
+  :global(.dark) .tag-filter {
+    --tag-text: #d1d5db;
+    --tag-bg: #ffffff0d;
+    --tag-border: #ffffff20;
+    --tag-hover: #ffffff18;
+    --tag-selected-bg: #e5e7eb;
+    --tag-selected-text: #111827;
+  }
+
+  .tag-filter__heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .tag-filter__heading h2 {
+    margin: 0;
+    color: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1.4;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .tag-filter__actions {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 0.6875rem;
+    line-height: 1.4;
+  }
+
+  .tag-filter__selected {
+    opacity: 0.55;
+    white-space: nowrap;
+  }
+
+  .tag-filter__clear {
+    padding: 0;
+    border: 0;
+    color: inherit;
+    background: transparent;
+    font: inherit;
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+    cursor: pointer;
+    opacity: 0.7;
+  }
+
+  .tag-filter__clear:hover {
+    opacity: 1;
+  }
+
+  .tag-filter__items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .tag-filter__chip {
+    position: relative;
+    min-width: 4.5rem;
+    max-width: 100%;
+    min-height: 2.5rem;
+    padding: 0.45rem 1.7rem 0.65rem 0.7rem;
+    overflow: hidden;
+    border: 1px solid var(--tag-border);
+    border-radius: 0.45rem;
+    color: inherit;
+    background: var(--tag-bg);
+    font: inherit;
+    line-height: 1.25;
+    text-align: start;
+    cursor: pointer;
+    transition:
+      transform 160ms ease,
+      color 160ms ease,
+      background-color 160ms ease,
+      border-color 160ms ease;
+  }
+
+  .tag-filter__chip:hover {
+    background: var(--tag-hover);
+    transform: translateY(-1px);
+  }
+
+  .tag-filter__chip:active {
+    transform: scale(0.97);
+  }
+
+  .tag-filter__chip[aria-pressed='true'] {
+    border-color: var(--tag-selected-bg);
+    color: var(--tag-selected-text);
+    background: var(--tag-selected-bg);
+  }
+
+  .tag-filter__label {
+    display: block;
+    overflow: hidden;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tag-filter__count {
+    position: absolute;
+    right: 0.45rem;
+    bottom: 0.22rem;
+    font-family: 'DM Mono', monospace;
+    font-size: 0.625rem;
+    line-height: 1;
+    opacity: 0.62;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .tag-filter__chip {
+      transition: none;
+    }
+
+    .tag-filter__chip:hover,
+    .tag-filter__chip:active {
+      transform: none;
+    }
+  }
+</style>

--- a/src/components/views/TagFilter.astro
+++ b/src/components/views/TagFilter.astro
@@ -75,7 +75,7 @@ const { tags } = Astro.props
     align-items: baseline;
     justify-content: space-between;
     gap: 0.75rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.5rem;
   }
 
   .tag-filter__heading h2 {
@@ -120,18 +120,18 @@ const { tags } = Astro.props
   .tag-filter__items {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.35rem;
   }
 
   .tag-filter__chip {
     position: relative;
-    min-width: 4.5rem;
+    min-width: 3.75rem;
     max-width: 100%;
-    min-height: 2.5rem;
-    padding: 0.45rem 1.7rem 0.65rem 0.7rem;
+    min-height: 2.05rem;
+    padding: 0.3rem 1.25rem 0.42rem 0.55rem;
     overflow: hidden;
     border: 1px solid var(--tag-border);
-    border-radius: 0.45rem;
+    border-radius: 0.35rem;
     color: inherit;
     background: var(--tag-bg);
     font: inherit;
@@ -171,10 +171,10 @@ const { tags } = Astro.props
 
   .tag-filter__count {
     position: absolute;
-    right: 0.45rem;
-    bottom: 0.22rem;
+    right: 0.32rem;
+    bottom: 0.14rem;
     font-family: 'DM Mono', monospace;
-    font-size: 0.625rem;
+    font-size: 0.5625rem;
     line-height: 1;
     opacity: 0.62;
   }

--- a/src/content/blogs/Agent-开发习惯.md
+++ b/src/content/blogs/Agent-开发习惯.md
@@ -2,7 +2,7 @@
 title: Agent 开发习惯
 description: 从配置管理、共享状态到异步调用、日志、异常处理与 Prompt 编写，整理 Agent 服务开发中的实用规范。
 pubDate: 2026-08-06
-tags: [Agent, Python, FastAPI, LLM]
+tags: [Agent]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/Astro.md
+++ b/src/content/blogs/Astro.md
@@ -2,7 +2,7 @@
 title: Astro Notes
 description: Astro Grammer & Blog Development
 pubDate: 2026-04-01
-tags: [Astro, 静态站点, 博客开发]
+tags: [Astro]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/CLI-从零实战教程.md
+++ b/src/content/blogs/CLI-从零实战教程.md
@@ -2,7 +2,7 @@
 title: 从零写 CLI：Python 与 JavaScript / TypeScript 实战教程
 description: 从命令设计、参数解析到测试与发布，系统梳理 Python 和 JavaScript / TypeScript CLI 的实战方法。
 pubDate: 2026-08-06
-tags: [CLI, Python, JavaScript, TypeScript]
+tags: [CLI]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/DeepSeek Harness 架构解析.md
+++ b/src/content/blogs/DeepSeek Harness 架构解析.md
@@ -2,7 +2,7 @@
 title: DeepSeek Harness 架构解析：从 Cordis 到一切皆插件的 Agent Runtime
 description: 解析 DeepSeek Harness 如何用 Cordis 将 Agent Runtime 拆解为可组合插件。
 pubDate: 2026-08-15
-tags: [Agent, DeepSeek, Cordis, 架构]
+tags: [DSH, Agent Harness]
 ---
 
 DeepSeek Harness（DSH）首先是一个基于 Cordis 的 Agent 运行时。它的目标不是像 [pi](https://github.com/earendil-works/pi) 一样提供一个固定 Agent 核心，再允许用户在外围增加功能；它把组成 Agent 的能力（llm、session、tools、system-prompt等）拆开，通过插件配置把它们组装成一个具体产品。

--- a/src/content/blogs/MCP.md
+++ b/src/content/blogs/MCP.md
@@ -2,7 +2,7 @@
 title: MCP（Model Context Protocol）
 description: MCP tutorial
 pubDate: 2026-05-15
-tags: [MCP, AI Agent, Function Calling]
+tags: [MCP]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/Prompt Caching 的工程策略: LLM 推理框架缓存机制设计 & Agent 提示词设计.md
+++ b/src/content/blogs/Prompt Caching 的工程策略: LLM 推理框架缓存机制设计 & Agent 提示词设计.md
@@ -2,11 +2,7 @@
 title: "Prompt Caching 的工程策略: LLM 推理框架缓存机制设计 & Agent 提示词设计"
 subtitle: 以前缀稳定性为中心，理解会话树、工具加载与上下文压缩
 description: 从 token 前缀匹配出发，系统梳理对话缓存的复用条件、常见失效模式，以及 append-only、按需工具加载和主动压缩等工程策略。
-tags:
-  - LLM
-  - 缓存
-  - Agent
-  - 对话系统
+tags: [Prompt Caching, KV Cache]
 pubDate: 2026-07-24
 ogImage: false
 toc: true

--- a/src/content/blogs/agent-skill-best-practices.md
+++ b/src/content/blogs/agent-skill-best-practices.md
@@ -2,7 +2,7 @@
 title: 创建 Agent Skill 的最佳实践
 description: 从简洁性、触发发现、渐进式披露、脚本化和验证等方面，整理专业 Agent Skill 的设计方法。
 pubDate: 2026-04-15
-tags: [Agent, Skill, Context Engineering]
+tags: [Skill]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/agent-system-testing.md
+++ b/src/content/blogs/agent-system-testing.md
@@ -2,7 +2,7 @@
 title: Agent 上线前常用的系统测试方法总述
 description: 从功能正确性、回复质量、鲁棒安全性、性能稳定性和上线验证五个维度，系统梳理 Agent 上线前的测试方法。
 pubDate: 2026-08-31
-tags: [Agent, 测试, Eval, Trace]
+tags: [Agent, Eval]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/claude-code-memory.md
+++ b/src/content/blogs/claude-code-memory.md
@@ -2,7 +2,7 @@
 title: Claude Code 记忆系统笔记
 description: 梳理 Claude Code 的 CLAUDE.md 与 Auto Memory 机制、生命周期、存储结构和排错方法。
 pubDate: 2026-08-08
-tags: [Claude Code, Agent, Context Engineering]
+tags: [Claude Code, Agent Memory]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/deer-workflow-pr-7-pi-agent.md
+++ b/src/content/blogs/deer-workflow-pr-7-pi-agent.md
@@ -2,7 +2,7 @@
 title: "Deer Workflow PR #7：Pi Coding Agent 统一 Harness 实现报告"
 description: "拆解 Deer Workflow PR #7 如何通过 subprocess Harness 接入 Pi Coding Agent，并保持统一的 Agent 调用与结构化输出契约。"
 pubDate: 2026-09-06
-tags: [Agent, Pi, Deer Workflow, Multi-Agent]
+tags: [Workflow, Pi, Multi-Agent]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/kv-prefix-prompt-context-caching.md
+++ b/src/content/blogs/kv-prefix-prompt-context-caching.md
@@ -2,7 +2,7 @@
 title: KV、Prefix、Prompt 与 Context Caching
 description: 从 KV Cache、Prefix Caching、Prompt Caching 到 Context Caching，梳理 LLM 缓存的作用域、复用条件与工程实现。
 pubDate: 2026-09-02
-tags: [LLM, 缓存, Agent, Context Engineering]
+tags: [KV Cache]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/memu-pr-675-pi-host-adapter.md
+++ b/src/content/blogs/memu-pr-675-pi-host-adapter.md
@@ -2,7 +2,7 @@
 title: "memU PR #675：Pi Coding Agent 专用 Host Adapter 实现报告"
 description: "从 session 解析、记忆流水线、检索安装与调度边界，拆解 memU PR #675 的 Pi 适配器实现。"
 pubDate: 2026-09-06
-tags: [memU, Pi Coding Agent, Agent, 记忆系统]
+tags: [memU, Agent Memory, Pi]
 ogImage: false
 toc: true
 search: true
@@ -800,4 +800,3 @@ memu-pi 是否安装、backend 是否可用：memU 安装指南负责
 第六，脱敏应发生在 prepared 输出边界。这样可以同时保住原始 session、分类依据和 cursor，又能减少交给整理 Agent 的运行元数据。对会持续演化的 provider-native JSON，删除已知字段比重建固定白名单更能保持向前兼容。
 
 第七，review 修复要检查最终净 diff。共享行为修正不代表应顺手修改所有宿主文档；本 PR 曾扩到 Claude Code、Cursor、Hermes，随后主动撤回，只保留 Pi 与必要的共享 scheduler 改动。
-

--- a/src/content/blogs/memu.md
+++ b/src/content/blogs/memu.md
@@ -2,7 +2,7 @@
 title: 看懂 memU：从运行方式到完整记忆链路
 description: 从运行方式、宿主接入到完整记忆链路，梳理 memU 如何保存、检索和复用 Agent 记忆。
 pubDate: 2026-08-31
-tags: [memU, Agent, Memory, Context Engineering]
+tags: [memU, Agent Memory]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/openviking-pr-4736-vikingbot-concurrency.md
+++ b/src/content/blogs/openviking-pr-4736-vikingbot-concurrency.md
@@ -2,7 +2,7 @@
 title: "OpenViking PR #4736：VikingBot 跨会话有界并发实现报告"
 description: 从事件循环、消息队列、Task 调度、会话锁与全局 semaphore，拆解 VikingBot 的跨会话并发实现。
 pubDate: 2026-09-06
-tags: [OpenViking, VikingBot, asyncio, 并发]
+tags: [OpenViking, Agent, Memory, PR]
 ogImage: false
 toc: true
 search: true
@@ -732,4 +732,3 @@ AgentLoop.run() = 消费消息 + 创建独立 Task + 继续消费
 因此最终行为可以准确表述为：
 
 > VikingBot 仍由一个 AgentLoop 从一个全局队列接收所有 channel 的消息，但消息进入 AgentLoop 后不再全局逐条处理。每条消息被注册为独立 asyncio Task；不同 SessionKey 的 Task 可以在同一事件循环中异步并发，同一 SessionKey 的 Task 通过专属锁按到达顺序执行，所有 SessionKey 再共同受全局 semaphore 限制，默认最多同时执行 4 条消息。
-

--- a/src/content/blogs/rag-system-testing.md
+++ b/src/content/blogs/rag-system-testing.md
@@ -2,7 +2,7 @@
 title: RAG 系统测试——以电商 APP 客服问答为例
 description: 以虚构电商客服场景为例，拆解 RAG 的意图识别、召回、精准率、生成忠实度和系统性能测试。
 pubDate: 2026-08-31
-tags: [RAG, Agent, 测试, Eval]
+tags: [RAG, Eval]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/云端 Agent.md
+++ b/src/content/blogs/云端 Agent.md
@@ -2,7 +2,7 @@
 title: 云端 Agent
 description: 从存算分离、持久化工作区到沙箱执行，梳理云端 Agent 的架构设计。
 pubDate: 2026-08-14
-tags: [Agent, Cloudflare, Sandbox]
+tags: [Cloud Agent, VM/FS]
 ---
 
 ## “Your agent needs a computer, not a container.”

--- a/src/content/blogs/本机Homebrew工具笔记.md
+++ b/src/content/blogs/本机Homebrew工具笔记.md
@@ -3,7 +3,7 @@ title: 本机 Homebrew 工具笔记
 description: 记录 Apple Silicon Mac 上主动安装的 Homebrew 工具、开发环境分层与常用命令。
 pubDate: 2026-02-02
 lastModDate: ''
-tags: [macOS, Homebrew, 开发环境, 工具]
+tags: [macOS]
 ogImage: false
 toc: true
 search: true

--- a/src/content/blogs/鉴权.md
+++ b/src/content/blogs/鉴权.md
@@ -2,7 +2,7 @@
 title: 前后端鉴权方案
 description: Front and Back-end Authentication Scheme
 pubDate: 2026-02-15
-tags: [鉴权, JWT, OAuth 2.0]
+tags: [鉴权]
 ogImage: false
 toc: true
 search: true

--- a/src/pages/blogs/index.mdx
+++ b/src/pages/blogs/index.mdx
@@ -16,11 +16,7 @@ import ListView from '~/components/views/ListView.astro'
   bgType={frontmatter.bgType}
   ogImage={frontmatter.ogImage}
 >
-  <StandardLayout
-    class="prose"
-    title={frontmatter.title}
-    subtitle={frontmatter.subtitle}
-  >
+  <StandardLayout title={frontmatter.title} subtitle={frontmatter.subtitle}>
     <ListView collectionType="blogs" urlPath="blogs" />
   </StandardLayout>
 </BaseLayout>

--- a/src/utils/blog-tag-filter.js
+++ b/src/utils/blog-tag-filter.js
@@ -1,0 +1,60 @@
+/**
+ * Normalizes one post's tags without changing their case.
+ *
+ * @param {string[]} tags
+ * @returns {string[]}
+ */
+export function normalizePostTags(tags) {
+  return [...new Set(tags.map((tag) => tag.trim()).filter(Boolean))]
+}
+
+/**
+ * Counts how many posts contain each tag and returns a stable display order.
+ *
+ * @param {string[][]} postsTags
+ * @returns {{ tag: string, count: number }[]}
+ */
+export function buildTagSummary(postsTags) {
+  const counts = new Map()
+
+  for (const tags of postsTags) {
+    for (const tag of normalizePostTags(tags)) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1)
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort(
+      (a, b) =>
+        b.count - a.count ||
+        a.tag.localeCompare(b.tag, 'zh-Hans-CN', {
+          numeric: true,
+          sensitivity: 'base',
+        })
+    )
+}
+
+/**
+ * Returns whether a post contains every selected tag.
+ *
+ * @param {string[]} postTags
+ * @param {Iterable<string>} selectedTags
+ */
+export function matchesAllTags(postTags, selectedTags) {
+  const normalizedTags = new Set(normalizePostTags(postTags))
+  return [...selectedTags].every((tag) => normalizedTags.has(tag))
+}
+
+/**
+ * Truncates a label by Unicode code point while keeping its full value intact.
+ *
+ * @param {string} tag
+ * @param {number} [maxLength]
+ */
+export function truncateTagLabel(tag, maxLength = 12) {
+  const characters = Array.from(tag)
+  return characters.length > maxLength
+    ? `${characters.slice(0, maxLength).join('')}…`
+    : tag
+}

--- a/test/blog-tag-filter.test.mjs
+++ b/test/blog-tag-filter.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildTagSummary,
+  matchesAllTags,
+  normalizePostTags,
+  truncateTagLabel,
+} from '../src/utils/blog-tag-filter.js'
+
+test('normalizes whitespace, empty values, and duplicates per post', () => {
+  assert.deepEqual(normalizePostTags([' Agent ', '', 'Agent', 'RAG']), [
+    'Agent',
+    'RAG',
+  ])
+})
+
+test('counts posts once per tag and sorts by count then name', () => {
+  assert.deepEqual(
+    buildTagSummary([['RAG', 'Agent', 'Agent'], ['Agent', '测试'], ['RAG']]),
+    [
+      { tag: 'Agent', count: 2 },
+      { tag: 'RAG', count: 2 },
+      { tag: '测试', count: 1 },
+    ]
+  )
+})
+
+test('matches empty, single, and multiple AND selections', () => {
+  const tags = ['Agent', 'RAG', '测试']
+
+  assert.equal(matchesAllTags(tags, []), true)
+  assert.equal(matchesAllTags(tags, ['Agent']), true)
+  assert.equal(matchesAllTags(tags, ['Agent', 'RAG']), true)
+  assert.equal(matchesAllTags(tags, ['Agent', 'Java']), false)
+})
+
+test('truncates by Unicode code point without changing short labels', () => {
+  assert.equal(truncateTagLabel('Context Engineering'), 'Context Engi…')
+  assert.equal(truncateTagLabel('Agent'), 'Agent')
+  assert.equal(truncateTagLabel('😀😀😀', 2), '😀😀…')
+})


### PR DESCRIPTION
## 变更概述

- 汇总当前可见 Blog 的全部标签，并显示每个标签对应的文章数
- 增加支持多选的 AND 筛选、`140ms` 防抖更新、年份联动和空结果状态
- 宽屏标签面板位于文章左侧并与 `Blogs` 标题顶部对齐；窄屏自动移动到副标题与年份列表之间
- 标签面板保持普通文档流，页面向下滚动时自然移出视口
- 收紧标签块尺寸，并适配 Light / Dark、键盘焦点和 reduced motion
- 按要求整理 18 篇 Blog 的标签，并补充中英文 README、项目解析和功能维护文档

## 设计与实现文档

本功能的详细设计、实现约束、实现校准和验收记录统一维护在 Issue #19：

- Issue：[feat(blogs): 增加响应式标签汇聚与多标签筛选](https://github.com/wutongyuonce/wutong-yu-blog/issues/19)
- 项目文档：[`docs/feature/Blogs标签汇聚与筛选说明.md`](https://github.com/wutongyuonce/wutong-yu-blog/blob/codex/feat/blogs-tag-filter/docs/feature/Blogs标签汇聚与筛选说明.md)

后续如需进一步修改筛选语义、布局断点、标签样式或内容标签，请先查看 Issue #19 或上述项目文档，并同步更新对应测试与验收记录。

## 验证

- `pnpm test:blog-tags`：4/4 通过
- 18 篇变更文章的 content metadata 校验：通过
- 变更实现文件的 ESLint 与 Prettier：通过
- `pnpm build`：通过，共生成 30 个页面
- 浏览器验证：1280px、1024px、390px 布局通过
- 单选、多标签 AND、零结果、Clear、快速连续选择、明暗主题、滚动行为和 Astro 客户端往返：通过

## 已知仓库基线

- `pnpm check` 仍报告本次变更外既有的 `mdast`、`hast`、`vfile` 类型声明缺失。
- 全量 `pnpm lint` 仍报告本次变更外既有的 `Snow.astro` 和 `unocss.config.ts` 两处规则错误。

Closes #19
