### PR TITLE
feat: add home blog statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ pnpm dev          # 启动本地开发服务器
 pnpm check        # 运行 Astro 类型与内容检查
 pnpm build        # 生成生产环境构建产物
 pnpm preview      # 本地预览生产构建
-pnpm test:blog-tags # 验证博客标签汇总与 AND 匹配逻辑
+pnpm test:blog-tags  # 验证博客标签汇总与 AND 匹配逻辑
+pnpm test:blog-stats # 验证首页 Blog 统计的字数、日期跨度与格式化逻辑
 pnpm lint         # 运行 ESLint 检查
 pnpm lint:fix     # 自动修复 lint 问题
 pnpm format       # 检查代码格式（Prettier）
@@ -170,7 +171,7 @@ src/
   pages/          # 路由定义
   styles/         # main.css, prose.css, markdown.css
   utils/          # 路径、日期、数据、标签筛选、杂项、目录工具函数
-test/             # Node 内置测试，目前覆盖博客标签纯逻辑
+test/             # Node 内置测试，覆盖博客标签与首页 Blog 统计纯逻辑
 plugins/          # remark/rehype 插件、OG 辅助
 public/           # 静态资源：favicon、字体、生成的图片等
 docs/             # 项目笔记与定制说明文档

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "test:blog-tags": "node --test test/blog-tag-filter.test.mjs",
+    "test:blog-stats": "node --test test/blog-stats.test.mjs",
     "format": "prettier . --check --ignore-unknown",
     "format:write": "prettier . --write --ignore-unknown --cache",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0 --cache",

--- a/plugins/remark-reading-time.ts
+++ b/plugins/remark-reading-time.ts
@@ -1,10 +1,13 @@
 import { toString } from 'mdast-util-to-string'
 
+import { countReadableUnits } from '../src/utils/blog-stats'
+
 import type { Root } from 'mdast'
 import type { VFile } from 'vfile'
 
 interface ReadingTimeFrontmatter {
   minutesRead?: number | boolean
+  wordCount?: number
 }
 
 type AstroReadingTimeFile = VFile & {
@@ -20,26 +23,21 @@ type AstroReadingTimeFile = VFile & {
  *
  * @see https://docs.astro.build/en/recipes/reading-time/
  */
-const CJK_CHAR_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu
-const WORD_RE = /[\p{L}\p{N}_'-]+/gu
 const WORDS_PER_MINUTE = 200
 
 function estimateReadingMinutes(text: string) {
-  const cjkChars = text.match(CJK_CHAR_RE)?.length ?? 0
-  const nonCjkText = text.replace(CJK_CHAR_RE, ' ')
-  const words = nonCjkText.match(WORD_RE)?.length ?? 0
-  const totalUnits = cjkChars + words
-
-  return Math.max(1, Math.round(totalUnits / WORDS_PER_MINUTE))
+  return Math.max(1, Math.round(countReadableUnits(text) / WORDS_PER_MINUTE))
 }
 
 function remarkReadingTime() {
   return (tree: Root, file: VFile) => {
     const astroFile = file as AstroReadingTimeFile
     const { frontmatter } = astroFile.data.astro
+    const textOnPage = toString(tree)
+
+    frontmatter.wordCount = countReadableUnits(textOnPage)
     if (frontmatter.minutesRead || frontmatter.minutesRead === 0) return
 
-    const textOnPage = toString(tree)
     frontmatter.minutesRead = estimateReadingMinutes(textOnPage)
   }
 }

--- a/src/components/home/HomeHeader.astro
+++ b/src/components/home/HomeHeader.astro
@@ -1,5 +1,7 @@
 ---
 import TinyDesktop from '~/components/home/TinyDesktop.astro'
+import { getBlogStats } from '~/utils/data'
+import { formatChineseCount } from '~/utils/blog-stats'
 
 interface Props {
   title: string
@@ -7,12 +9,20 @@ interface Props {
 }
 
 const { title, subtitle } = Astro.props
+const stats = await getBlogStats()
 ---
 
 <div class="home-title-row">
   <div class="home-title-copy">
     <h1 class="page-title">{title}</h1>
     {subtitle && <p class="home-title-subtitle op-50 italic">{subtitle}</p>}
+    <p class="home-title-stats" aria-label="Blog 统计">
+      <span>{stats.postCount}篇</span>
+      <span aria-hidden="true">·</span>
+      <span>{formatChineseCount(stats.wordCount)}字</span>
+      <span aria-hidden="true">·</span>
+      <span>{stats.daySpan}天</span>
+    </p>
   </div>
   <TinyDesktop />
 </div>
@@ -32,6 +42,24 @@ const { title, subtitle } = Astro.props
 
   .home-title-subtitle {
     margin-top: -2rem !important;
+  }
+
+  .home-title-stats {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    margin: 1.15rem 0 0 !important;
+    color: color-mix(in srgb, var(--c-text) 46%, transparent);
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.82rem;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.045em;
+    line-height: 1;
+  }
+
+  .home-title-stats span[aria-hidden='true'] {
+    color: color-mix(in srgb, var(--c-text) 24%, transparent);
   }
 
   @media (max-width: 720px) {

--- a/src/utils/blog-stats.js
+++ b/src/utils/blog-stats.js
@@ -1,0 +1,49 @@
+const DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000
+
+const CJK_CHAR_RE =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu
+const WORD_RE = /[\p{L}\p{N}_'-]+/gu
+
+/**
+ * Counts readable CJK characters and non-CJK words in plain text.
+ *
+ * @param {string} text
+ */
+export function countReadableUnits(text) {
+  const cjkChars = text.match(CJK_CHAR_RE)?.length ?? 0
+  const nonCjkText = text.replace(CJK_CHAR_RE, ' ')
+  const words = nonCjkText.match(WORD_RE)?.length ?? 0
+
+  return cjkChars + words
+}
+
+/**
+ * Returns the number of calendar days between the earliest and latest date.
+ *
+ * @param {Date[]} dates
+ */
+export function getCalendarDaySpan(dates) {
+  if (dates.length < 2) return 0
+
+  const days = dates.map((date) =>
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  )
+
+  return Math.round(
+    (Math.max(...days) - Math.min(...days)) / DAY_IN_MILLISECONDS
+  )
+}
+
+/**
+ * Uses ten-thousands for long Chinese counts while preserving exact small counts.
+ *
+ * @param {number} count
+ */
+export function formatChineseCount(count) {
+  if (count < 10_000) return count.toLocaleString('zh-CN')
+
+  const tenThousands = count / 10_000
+  const precision = tenThousands < 100 ? 1 : 0
+
+  return `${tenThousands.toFixed(precision).replace(/\.0$/, '')}万`
+}

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,6 +1,7 @@
 import { getCollection, render } from 'astro:content'
 
 import { getYear } from '~/utils/datetime'
+import { getCalendarDaySpan } from '~/utils/blog-stats'
 
 import type { CollectionEntry } from 'astro:content'
 
@@ -60,6 +61,29 @@ export function getSortedPosts(
   return [...posts].sort(
     (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
   )
+}
+
+export interface BlogStats {
+  postCount: number
+  wordCount: number
+  daySpan: number
+}
+
+/**
+ * Summarizes published blog content for the home page.
+ */
+export async function getBlogStats(): Promise<BlogStats> {
+  const posts = await getCollection('blogs', ({ data }) => !data.draft)
+  const renderedPosts = await Promise.all(posts.map((post) => render(post)))
+
+  return {
+    postCount: posts.length,
+    wordCount: renderedPosts.reduce(
+      (total, post) => total + (post.remarkPluginFrontmatter.wordCount ?? 0),
+      0
+    ),
+    daySpan: getCalendarDaySpan(posts.map(({ data }) => data.pubDate)),
+  }
 }
 
 export interface GroupedBlogItem {

--- a/test/blog-stats.test.mjs
+++ b/test/blog-stats.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  countReadableUnits,
+  formatChineseCount,
+  getCalendarDaySpan,
+} from '../src/utils/blog-stats.js'
+
+test('counts CJK characters and non-CJK words without whitespace', () => {
+  assert.equal(countReadableUnits('你好 Astro 5, hello-world!'), 5)
+})
+
+test('calculates a calendar-day span independently of time of day', () => {
+  assert.equal(
+    getCalendarDaySpan([
+      new Date('2026-01-01T23:59:59Z'),
+      new Date('2026-01-03T00:00:01Z'),
+    ]),
+    2
+  )
+  assert.equal(getCalendarDaySpan([new Date('2026-01-01')]), 0)
+})
+
+test('formats large Chinese counts in ten-thousands', () => {
+  assert.equal(formatChineseCount(9_999), '9,999')
+  assert.equal(formatChineseCount(12_300), '1.2万')
+  assert.equal(formatChineseCount(1_370_000), '137万')
+})


### PR DESCRIPTION
## Summary

- derive published Blog count, readable word units, and earliest-to-latest publication span from the Astro content collection
- render a minimal responsive statistics row below the Home subtitle
- reuse the Markdown text extraction path for word counting and add focused unit tests and README commands

## Code review

- Standards: pass after syncing the new test command and coverage description to README
- Spec: pass; no missing requirements, incorrect behavior, or scope creep found

## Validation

- `pnpm test:blog-stats`
- `pnpm test:blog-tags`
- `pnpm check`
- `pnpm build`
- targeted ESLint and Prettier checks for changed code
- `git diff main...HEAD --check`

## Existing baseline issues

- full `pnpm lint` still reports pre-existing errors in `src/components/backgrounds/Snow.astro` and `unocss.config.ts`
- full `pnpm format` still reports pre-existing formatting differences across 29 files; changed files were checked separately