### PR TITLE
feat: add navigation progress stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preview": "astro preview",
     "test:blog-tags": "node --test test/blog-tag-filter.test.mjs",
     "test:blog-stats": "node --test test/blog-stats.test.mjs",
+    "test:progress-stats": "node --test test/progress-stats.test.mjs",
     "format": "prettier . --check --ignore-unknown",
     "format:write": "prettier . --write --ignore-unknown --cache",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0 --cache",

--- a/src/components/nav/NavBar.astro
+++ b/src/components/nav/NavBar.astro
@@ -1,5 +1,6 @@
 ---
 import LogoButton from '~/components/widgets/LogoButton.astro'
+import ProgressStats from '~/components/widgets/ProgressStats.astro'
 import Divider from '~/components/base/Divider.astro'
 import SearchSwitch from '~/components/widgets/SearchSwitch.astro'
 import ThemeSwitch from '~/components/widgets/ThemeSwitch.astro'
@@ -23,7 +24,10 @@ for (const item of new Set(left)) {
 <header
   class={`nav-bar flex items-center gap-6 p-[1.75rem_2rem_2rem] ${mergeOnMobile ? 'lt-md:px-7' : 'lt-md:(px-6 gap-3)'}`}
 >
-  <LogoButton />
+  <div class="nav-bar__brand">
+    <LogoButton />
+    <ProgressStats />
+  </div>
   <nav
     class={`nav-bar__nav flex items-center gap-4.8 w-full lt-md:justify-end
     ${left.length !== 0 ? (right.length !== 0 ? 'justify-between' : '') : 'justify-end'}`}
@@ -145,6 +149,12 @@ for (const item of new Set(left)) {
     gap: 1.2rem;
   }
 
+  .nav-bar__brand {
+    display: flex;
+    align-items: center;
+    flex: none;
+  }
+
   .nav-bar__group {
     display: grid;
     grid-auto-flow: column;
@@ -158,7 +168,8 @@ for (const item of new Set(left)) {
 
   @media (max-width: 767.9px) {
     .nav-bar {
-      padding-inline: 1.75rem;
+      gap: 0.75rem;
+      padding-inline: 1rem;
     }
 
     .nav-bar__nav {

--- a/src/components/widgets/ProgressStats.astro
+++ b/src/components/widgets/ProgressStats.astro
@@ -1,0 +1,134 @@
+<div class="progress-stats" role="group" aria-label="时间进度">
+  <div class="progress-stat progress-stat--day">
+    <strong data-progress-value="day">--</strong>
+    <span>今年第几天</span>
+  </div>
+  <div class="progress-stat">
+    <strong><span data-progress-value="year">--</span><small>%</small></strong>
+    <span>年度进度</span>
+  </div>
+  <div class="progress-stat">
+    <strong><span data-progress-value="today">--</span><small>%</small></strong>
+    <span>今日进度</span>
+  </div>
+</div>
+
+<script>
+  import { getProgressStats } from '~/utils/progress-stats.js'
+
+  const updateProgressStats = () => {
+    const stats = getProgressStats()
+
+    document
+      .querySelectorAll<HTMLElement>('[data-progress-value="day"]')
+      .forEach((element) => (element.textContent = String(stats.dayOfYear)))
+    document
+      .querySelectorAll<HTMLElement>('[data-progress-value="year"]')
+      .forEach(
+        (element) =>
+          (element.textContent = String(Math.round(stats.yearProgress)))
+      )
+    document
+      .querySelectorAll<HTMLElement>('[data-progress-value="today"]')
+      .forEach(
+        (element) =>
+          (element.textContent = String(Math.round(stats.dayProgress)))
+      )
+  }
+
+  const startProgressClock = () => {
+    updateProgressStats()
+
+    if (document.documentElement.dataset.progressClock) return
+    document.documentElement.dataset.progressClock = 'active'
+    window.setInterval(updateProgressStats, 30_000)
+  }
+
+  document.addEventListener('astro:page-load', startProgressClock)
+  startProgressClock()
+</script>
+
+<style>
+  .progress-stats {
+    display: flex;
+    align-items: center;
+    gap: clamp(0.9rem, 1.8vw, 1.5rem);
+    padding-left: clamp(0.9rem, 1.8vw, 1.5rem);
+    border-left: 1px solid color-mix(in srgb, var(--c-text) 14%, transparent);
+    color: color-mix(in srgb, var(--c-text) 58%, transparent);
+    white-space: nowrap;
+  }
+
+  .progress-stat {
+    display: grid;
+    gap: 0.12rem;
+  }
+
+  .progress-stat strong {
+    color: color-mix(in srgb, var(--c-text) 78%, transparent);
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 1.12rem;
+    font-variant-numeric: tabular-nums;
+    font-weight: 400;
+    letter-spacing: -0.04em;
+    line-height: 1;
+  }
+
+  .progress-stat--day strong {
+    color: #ad526c;
+  }
+
+  .progress-stat > span {
+    font-family: 'LXGWWenKai-Regular', sans-serif;
+    font-size: 0.64rem;
+    letter-spacing: 0.04em;
+    line-height: 1;
+  }
+
+  .progress-stat small {
+    margin-left: 0.08em;
+    font-size: 0.62em;
+    letter-spacing: -0.02em;
+    opacity: 0.72;
+  }
+
+  :global(html.dark) .progress-stats {
+    border-left-color: color-mix(in srgb, var(--c-text) 18%, transparent);
+    color: color-mix(in srgb, var(--c-text) 55%, transparent);
+  }
+
+  :global(html.dark) .progress-stat--day strong {
+    color: #e7a1b5;
+  }
+
+  @media (max-width: 767.9px) {
+    .progress-stats {
+      gap: 0.65rem;
+      padding-left: 0.7rem;
+    }
+
+    .progress-stat strong {
+      font-size: 0.82rem;
+    }
+
+    .progress-stat > span {
+      font-size: 0.5rem;
+      letter-spacing: 0;
+    }
+  }
+
+  @media (max-width: 389.9px) {
+    .progress-stats {
+      gap: 0.5rem;
+    }
+
+    .progress-stat strong {
+      font-size: 0.76rem;
+    }
+
+    .progress-stat > span {
+      font-size: 0.46rem;
+    }
+  }
+</style>

--- a/src/utils/progress-stats.js
+++ b/src/utils/progress-stats.js
@@ -1,0 +1,32 @@
+const DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000
+
+/**
+ * Returns calendar progress in the supplied date's local timezone.
+ *
+ * @param {Date} date
+ */
+export function getProgressStats(date = new Date()) {
+  const year = date.getFullYear()
+  const month = date.getMonth()
+  const day = date.getDate()
+  const startOfYear = new Date(year, 0, 1)
+  const startOfNextYear = new Date(year + 1, 0, 1)
+  const startOfToday = new Date(year, month, day)
+  const startOfTomorrow = new Date(year, month, day + 1)
+  const dayOfYear =
+    Math.floor(
+      (Date.UTC(year, month, day) - Date.UTC(year, 0, 1)) / DAY_IN_MILLISECONDS
+    ) + 1
+
+  return {
+    dayOfYear,
+    yearProgress:
+      ((date.getTime() - startOfYear.getTime()) /
+        (startOfNextYear.getTime() - startOfYear.getTime())) *
+      100,
+    dayProgress:
+      ((date.getTime() - startOfToday.getTime()) /
+        (startOfTomorrow.getTime() - startOfToday.getTime())) *
+      100,
+  }
+}

--- a/test/progress-stats.test.mjs
+++ b/test/progress-stats.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getProgressStats } from '../src/utils/progress-stats.js'
+
+test('starts a common year at day one with zero progress', () => {
+  assert.deepEqual(getProgressStats(new Date(2025, 0, 1)), {
+    dayOfYear: 1,
+    yearProgress: 0,
+    dayProgress: 0,
+  })
+})
+
+test('counts leap day and uses the full leap year', () => {
+  const stats = getProgressStats(new Date(2024, 1, 29, 12))
+
+  assert.equal(stats.dayOfYear, 60)
+  assert.equal(stats.dayProgress, 50)
+  assert.ok(stats.yearProgress > 16 && stats.yearProgress < 17)
+})
+
+test('tracks fractional progress through the local day', () => {
+  const stats = getProgressStats(new Date(2025, 6, 2, 6))
+
+  assert.equal(stats.dayOfYear, 183)
+  assert.equal(stats.dayProgress, 25)
+  assert.ok(stats.yearProgress > 49 && stats.yearProgress < 51)
+})


### PR DESCRIPTION
## Summary

- add live day-of-year, annual progress, and daily progress beside the navigation avatar
- round annual and daily percentages to integers and refresh them from the visitor local time
- match the existing blog typography across light, dark, desktop, and mobile layouts
- cover calendar calculations with focused tests

## Testing

- `pnpm test:progress-stats`
- `pnpm check`
- `pnpm build`
- targeted ESLint and Prettier checks for changed files

## Notes

- Full `pnpm lint` still reports the two pre-existing errors in `Snow.astro` and `unocss.config.ts`; changed files pass ESLint.