### PR TITLE
feat: add recent writing timeline to home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:blog-tags": "node --test test/blog-tag-filter.test.mjs",
     "test:blog-stats": "node --test test/blog-stats.test.mjs",
     "test:progress-stats": "node --test test/progress-stats.test.mjs",
+    "test:recent-post-date": "node --test test/recent-post-date.test.mjs",
     "format": "prettier . --check --ignore-unknown",
     "format:write": "prettier . --write --ignore-unknown --cache",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0 --cache",

--- a/src/components/home/RecentWriting.astro
+++ b/src/components/home/RecentWriting.astro
@@ -1,0 +1,262 @@
+---
+import { getRecentBlogPosts } from '~/utils/data'
+import { formatRecentPostDate } from '~/utils/recent-post-date.js'
+import { withBasePath } from '~/utils/path'
+
+const posts = await getRecentBlogPosts()
+---
+
+{
+  posts.length > 0 && (
+    <section class="recent-writing" aria-labelledby="recent-writing-title">
+      <header class="recent-writing__header">
+        <p>RECENT WRITING</p>
+        <h2 id="recent-writing-title">近期笔墨</h2>
+      </header>
+
+      <ol class="recent-writing__timeline">
+        {posts.map(({ id, data }, index) => {
+          const dateTime = data.pubDate.toISOString()
+
+          return (
+            <li class="recent-writing__item">
+              <span class="recent-writing__number" aria-hidden="true">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+
+              <div class="recent-writing__content">
+                <a
+                  class="recent-writing__link"
+                  href={withBasePath(`/blogs/${id}/`)}
+                >
+                  {data.title}
+                </a>
+                {data.tags.length > 0 && (
+                  <p class="recent-writing__tags">
+                    {data.tags.slice(0, 2).map((tag, index) => (
+                      <>
+                        {index > 0 && <span aria-hidden="true">·</span>}
+                        <span>{tag}</span>
+                      </>
+                    ))}
+                  </p>
+                )}
+              </div>
+
+              <time
+                class="recent-writing__date"
+                datetime={dateTime}
+                data-recent-post-date={dateTime}
+              >
+                {formatRecentPostDate(data.pubDate)}
+              </time>
+            </li>
+          )
+        })}
+      </ol>
+    </section>
+  )
+}
+
+<style>
+  .recent-writing {
+    --timeline-accent: #c98299;
+    --timeline-line: color-mix(in srgb, var(--c-text) 14%, transparent);
+    --timeline-number-bg: color-mix(in srgb, var(--c-bg) 95%, var(--c-text) 5%);
+    --timeline-number-border: color-mix(in srgb, var(--c-text) 7%, transparent);
+    --timeline-number-color: color-mix(in srgb, var(--c-text) 64%, transparent);
+    --timeline-number-shadow: 0 1px 5px
+      color-mix(in srgb, var(--c-text) 6%, transparent);
+    margin-top: clamp(4.5rem, 11vw, 7.5rem);
+    margin-bottom: 1rem;
+  }
+
+  :global(.dark) .recent-writing {
+    --timeline-accent: color-mix(in srgb, #d58ba3 82%, var(--c-text) 18%);
+    --timeline-line: color-mix(in srgb, var(--c-text) 20%, transparent);
+    --timeline-number-bg: color-mix(
+      in srgb,
+      var(--c-bg) 88%,
+      var(--c-text) 12%
+    );
+    --timeline-number-border: color-mix(in srgb, var(--c-text) 8%, transparent);
+    --timeline-number-color: color-mix(in srgb, var(--c-text) 72%, transparent);
+    --timeline-number-shadow: 0 2px 8px
+      color-mix(in srgb, var(--c-bg) 60%, transparent);
+  }
+
+  .recent-writing__header p {
+    margin: 0 0 0.55rem;
+    color: color-mix(in srgb, var(--c-text) 45%, transparent);
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.78rem;
+    letter-spacing: 0.24em;
+  }
+
+  .recent-writing__header h2 {
+    margin: 0;
+    border: 0;
+    font-family: 'SourceHanSerifCN-Regular', serif;
+    font-size: clamp(1.85rem, 5vw, 2.35rem);
+    font-weight: 400;
+    letter-spacing: 0.05em;
+    line-height: 1.2;
+  }
+
+  .recent-writing__timeline {
+    position: relative;
+    margin: clamp(2.5rem, 7vw, 4rem) 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .recent-writing__timeline::before {
+    position: absolute;
+    top: -1.75rem;
+    bottom: -1.4rem;
+    left: 1.31rem;
+    width: 2px;
+    border-radius: 999px;
+    background: linear-gradient(
+      to bottom,
+      transparent,
+      var(--timeline-accent) 7%,
+      var(--timeline-line) 24%,
+      var(--timeline-line) 90%,
+      transparent 100%
+    );
+    content: '';
+  }
+
+  .recent-writing__item {
+    position: relative;
+    display: grid;
+    grid-template-columns: 2.75rem minmax(0, 1fr) auto;
+    gap: 0.9rem;
+    align-items: start;
+    padding-bottom: 1.35rem;
+  }
+
+  :global(.prose) .recent-writing__timeline > .recent-writing__item {
+    padding-left: 0;
+  }
+
+  :global(.prose) .recent-writing__timeline > .recent-writing__item::before {
+    content: none;
+  }
+
+  .recent-writing__item:last-child {
+    min-height: 0;
+    padding-bottom: 0;
+  }
+
+  .recent-writing__number {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    place-items: center;
+    width: 2.4rem;
+    min-height: 1.8rem;
+    margin: 0.18rem auto 0;
+    border: 1px solid var(--timeline-number-border);
+    border-radius: 0.4rem;
+    background: var(--timeline-number-bg);
+    box-shadow: var(--timeline-number-shadow);
+    color: var(--timeline-number-color);
+    font-family: 'SourceHanSerifCN-Regular', serif;
+    font-size: 1.05rem;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+
+  .recent-writing__item:first-child .recent-writing__number {
+    border-color: color-mix(in srgb, var(--timeline-accent) 28%, transparent);
+    color: var(--timeline-accent);
+  }
+
+  .recent-writing__content {
+    min-width: 0;
+  }
+
+  .recent-writing__link {
+    color: color-mix(in srgb, var(--c-text) 92%, transparent);
+    font-family: 'SourceHanSerifCN-Regular', serif;
+    font-size: clamp(1.05rem, 2.6vw, 1.25rem);
+    line-height: 1.55;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+  }
+
+  .recent-writing__link:hover {
+    color: var(--c-text);
+    border-bottom-color: color-mix(in srgb, var(--c-text) 38%, transparent);
+  }
+
+  .recent-writing__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.38rem;
+    margin: 0.45rem 0 0;
+    color: color-mix(in srgb, var(--c-text) 45%, transparent);
+    font-size: 0.82rem;
+    line-height: 1.45;
+  }
+
+  .recent-writing__date {
+    padding-top: 0.25rem;
+    color: color-mix(in srgb, var(--c-text) 55%, transparent);
+    font-family: 'SourceHanSerifCN-Regular', serif;
+    font-size: 0.9rem;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.5;
+    white-space: nowrap;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .recent-writing__link {
+      transition:
+        color 160ms ease,
+        border-color 160ms ease;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .recent-writing__item {
+      grid-template-columns: 2.4rem minmax(0, 1fr);
+      column-gap: 0.75rem;
+      row-gap: 0.2rem;
+    }
+
+    .recent-writing__timeline::before {
+      left: 1.14rem;
+    }
+
+    .recent-writing__number {
+      width: 2.2rem;
+    }
+
+    .recent-writing__date {
+      grid-column: 2;
+      margin-top: 0;
+      padding-top: 0;
+      font-size: 0.82rem;
+    }
+  }
+</style>
+
+<script>
+  import { formatRecentPostDate } from '~/utils/recent-post-date.js'
+
+  const updateRecentWritingDates = () => {
+    document
+      .querySelectorAll<HTMLElement>('[data-recent-post-date]')
+      .forEach((element) => {
+        const publishedAt = element.dataset.recentPostDate
+        if (publishedAt) element.textContent = formatRecentPostDate(publishedAt)
+      })
+  }
+
+  updateRecentWritingDates()
+  document.addEventListener('astro:page-load', updateRecentWritingDates)
+</script>

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -10,6 +10,7 @@ import BaseLayout from '~/layouts/BaseLayout.astro'
 import StandardLayout from '~/layouts/StandardLayout.astro'
 import RenderPage from '~/components/views/RenderPage.astro'
 import HomeHeader from '~/components/home/HomeHeader.astro'
+import RecentWriting from '~/components/home/RecentWriting.astro'
 
 <BaseLayout
   title={frontmatter.title}
@@ -25,6 +26,7 @@ import HomeHeader from '~/components/home/HomeHeader.astro'
     />
     <div slot="article" class="home-content" style="margin-top: -1em;">
       <RenderPage collectionType="home" id="index" />
+      <RecentWriting />
     </div>
   </StandardLayout>
 </BaseLayout>

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -63,6 +63,18 @@ export function getSortedPosts(
   )
 }
 
+async function getPublishedBlogPosts() {
+  return await getCollection('blogs', ({ data }) => !data.draft)
+}
+
+/**
+ * Retrieves the five newest published posts for the home page.
+ */
+export async function getRecentBlogPosts() {
+  const posts = await getPublishedBlogPosts()
+  return getSortedPosts(posts).slice(0, 5)
+}
+
 export interface BlogStats {
   postCount: number
   wordCount: number
@@ -73,7 +85,7 @@ export interface BlogStats {
  * Summarizes published blog content for the home page.
  */
 export async function getBlogStats(): Promise<BlogStats> {
-  const posts = await getCollection('blogs', ({ data }) => !data.draft)
+  const posts = await getPublishedBlogPosts()
   const renderedPosts = await Promise.all(posts.map((post) => render(post)))
 
   return {

--- a/src/utils/recent-post-date.js
+++ b/src/utils/recent-post-date.js
@@ -1,0 +1,58 @@
+const DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000
+const SITE_TIME_ZONE = 'Asia/Shanghai'
+
+const calendarDateFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: SITE_TIME_ZONE,
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+})
+
+const fullDateFormatter = new Intl.DateTimeFormat('zh-CN', {
+  timeZone: SITE_TIME_ZONE,
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  weekday: 'long',
+})
+
+/**
+ * Converts an instant to its calendar-day timestamp in the site's timezone.
+ *
+ * @param {Date} date
+ */
+function getCalendarTimestamp(date) {
+  const parts = Object.fromEntries(
+    calendarDateFormatter
+      .formatToParts(date)
+      .filter(({ type }) => type !== 'literal')
+      .map(({ type, value }) => [type, Number(value)])
+  )
+
+  return Date.UTC(parts.year, parts.month - 1, parts.day)
+}
+
+/**
+ * Formats a blog date for the recent-writing timeline.
+ *
+ * @param {Date | string} publishedAt
+ * @param {Date} [now]
+ */
+export function formatRecentPostDate(publishedAt, now = new Date()) {
+  const publishedDate =
+    typeof publishedAt === 'string' ? new Date(publishedAt) : publishedAt
+
+  if (Number.isNaN(publishedDate.getTime()) || Number.isNaN(now.getTime())) {
+    throw new Error('Invalid Date')
+  }
+
+  const daysAgo = Math.round(
+    (getCalendarTimestamp(now) - getCalendarTimestamp(publishedDate)) /
+      DAY_IN_MILLISECONDS
+  )
+
+  if (daysAgo === 0) return '今天'
+  if (daysAgo > 0 && daysAgo <= 30) return `${daysAgo}天前`
+
+  return fullDateFormatter.format(publishedDate).replace(/\s/g, '')
+}

--- a/test/recent-post-date.test.mjs
+++ b/test/recent-post-date.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { formatRecentPostDate } from '../src/utils/recent-post-date.js'
+
+const now = new Date('2026-09-12T00:30:00+08:00')
+
+test('uses relative labels through the 30-day boundary', () => {
+  assert.equal(formatRecentPostDate('2026-09-12', now), '今天')
+  assert.equal(formatRecentPostDate('2026-09-11', now), '1天前')
+  assert.equal(formatRecentPostDate('2026-08-13', now), '30天前')
+})
+
+test('uses a full Chinese date and weekday after 30 days', () => {
+  assert.equal(formatRecentPostDate('2026-08-12', now), '2026年8月12日星期三')
+})
+
+test('does not describe future publication dates as days ago', () => {
+  assert.equal(formatRecentPostDate('2026-09-13', now), '2026年9月13日星期日')
+})


### PR DESCRIPTION
## Summary

- add a recent-writing timeline below the home-page introduction
- show the five newest published posts with responsive tags and links
- format dates by Asia/Shanghai calendar days and refresh relative labels in the browser
- match light/dark themes with an accessible, reduced-motion-aware presentation

## Review fixes

- centralize the published-post filtering policy shared by home statistics and the timeline
- limit link transitions to `prefers-reduced-motion: no-preference`

## Verification

- `node --test test/*.test.mjs` (14 tests)
- `pnpm check`
- `pnpm build`
- ESLint on changed Astro/TS/JS test files
- Prettier check on changed format-supported files
- production HTML assertion: exactly 5 timeline entries
- desktop/mobile and light/dark browser review

Repository-wide `pnpm lint` and `pnpm format` still report pre-existing failures in untouched files; the GitHub workflow runs `pnpm check` and `pnpm build`, both of which pass.

Closes #53